### PR TITLE
fix: sandwich recipes not showing up

### DIFF
--- a/LoveOfCooking/assets/NewRecipesPack/Objects/Egg Sandwich/object.json
+++ b/LoveOfCooking/assets/NewRecipesPack/Objects/Egg Sandwich/object.json
@@ -1,7 +1,7 @@
 ﻿{
     "Name": "blueberry.cac.eggsando",
     "Description": "...",
-    "Category": "Junk",
+    "Category": "Cooking",
     "CategoryTextOverride": "",
     "CategoryColorOverride": "0, 0, 0, 0",
     "Edibility": 66,

--- a/LoveOfCooking/assets/NewRecipesPack/Objects/Salad Sandwich/object.json
+++ b/LoveOfCooking/assets/NewRecipesPack/Objects/Salad Sandwich/object.json
@@ -1,7 +1,7 @@
 ﻿{
     "Name": "blueberry.cac.saladsando",
     "Description": "...",
-    "Category": "Junk",
+    "Category": "Cooking",
     "CategoryTextOverride": "",
     "CategoryColorOverride": "0, 0, 0, 0",
     "Edibility": 33,

--- a/LoveOfCooking/assets/NewRecipesPack/Objects/Seafood Sandwich/object.json
+++ b/LoveOfCooking/assets/NewRecipesPack/Objects/Seafood Sandwich/object.json
@@ -1,7 +1,7 @@
 ﻿{
     "Name": "blueberry.cac.seafoodsando",
     "Description": "...",
-    "Category": "Junk",
+    "Category": "Cooking",
     "CategoryTextOverride": "",
     "CategoryColorOverride": "0, 0, 0, 0",
     "Edibility": 47,


### PR DESCRIPTION
Since the sandwiches (whole, not half variants) are categorized as "Junk" they do not show up in the cooking menu. When their category is changed to "Cooking" instead of "Junk", they show up in the cooking menu as intended. 