### PR TITLE
Fix bug where item doesn't show above head when received

### DIFF
--- a/LoveOfCooking/Harmony/HarmonyPatches.cs
+++ b/LoveOfCooking/Harmony/HarmonyPatches.cs
@@ -120,8 +120,12 @@ namespace LoveOfCooking.HarmonyPatches
 						motion = new Vector2(0f, -0.1f)
 					};
 					Game1.currentLocation.temporarySprites.Add(sprite);
+					return false;
 				}
-				return false;
+				else
+				{
+					return true;
+				}
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
Hi! I play using your mod and it's awesome! I was bothered by this bug and saw lots of other folks mentioning it as well. So thought I would try to help out and I think I solved it! :)

I tested this change by:
1) building the code without the change, running a new game, saw no parsnips held above head on day 1
2) building the code with the change, running a new game, did see parsnips held above head on day 1

Thanks!