### PR TITLE
fix HP/EP regeneration bug in Update() method

### DIFF
--- a/LoveOfCooking/Objects/Regeneration.cs
+++ b/LoveOfCooking/Objects/Regeneration.cs
@@ -253,31 +253,31 @@ namespace LoveOfCooking
 			if (this.RemainingValue.HP > 0 && this.TicksCurrent.HP < this.TicksRequired.HP)
 			{
 				++this.TicksCurrent.HP;
-				if (this.TicksCurrent.HP >= rate.HP)
+			}
+			else if (this.TicksCurrent.HP >= rate.HP)
+			{
+				this.TicksCurrent.HP = 0;
+				if (this.RemainingValue.HP > 0)
 				{
-					this.TicksCurrent.HP = 0;
-					if (this.RemainingValue.HP > 0)
-					{
-						if (Game1.player.health < Game1.player.maxHealth)
-							++Game1.player.health;
-						--this.RemainingValue.HP;
-						diff = true;
-					}
+					if (Game1.player.health < Game1.player.maxHealth)
+						++Game1.player.health;
+					--this.RemainingValue.HP;
+					diff = true;
 				}
 			}
 			if (this.RemainingValue.EP > 0 && this.TicksCurrent.EP < this.TicksRequired.EP)
 			{
 				++this.TicksCurrent.EP;
-				if (this.TicksCurrent.EP >= rate.EP)
+			}
+			else if (this.TicksCurrent.EP >= rate.EP)
+			{
+				this.TicksCurrent.EP = 0;
+				if (this.RemainingValue.EP > 0)
 				{
-					this.TicksCurrent.EP = 0;
-					if (this.RemainingValue.EP > 0)
-					{
-						if (Game1.player.Stamina < Game1.player.MaxStamina)
-							++Game1.player.Stamina;
-						--this.RemainingValue.EP;
-						diff = true;
-					}
+					if (Game1.player.Stamina < Game1.player.MaxStamina)
+						++Game1.player.Stamina;
+					--this.RemainingValue.EP;
+					diff = true;
 				}
 			}
 			if (diff)


### PR DESCRIPTION
This commit fixes a small oversight which prevents HP/EP regeneration from working if the `this.TicksCurrent.HP` variable is bigger than `this.TicksRequired.HP` (the same applies to EP). The first `if` condition (`if (this.RemainingValue.HP > 0 && this.TicksCurrent.HP < this.TicksRequired.HP)`) prevents the code from reaching the second `if` condition (`if (this.TicksCurrent.HP >= rate.HP)`) where the regenerating happens because the `this.TicksCurrent` variable is bigger than the `this.TicksRequired` variable. This causes the `this.TicksCurrent` variable to never reset back to 0 and therefore the regeneration doesn't happen. 

I fixed this by putting the code in an `else if` block outside of the first `if` block.