### PR TITLE
Fix Cooking Chocolate being unavailable for purchase

### DIFF
--- a/LoveOfCooking [CP]/assets/shop-data.json
+++ b/LoveOfCooking [CP]/assets/shop-data.json
@@ -8,7 +8,7 @@
                 "{{ID}}_chocolate": {
                     "Id": "{{ID}}_chocolate",
                     "ItemId": "{{ID}}_chocolate",
-                    "Condition": "PLAYER_FARMHOUSE_UPGRADE Current 1, PLAYER_HAS_MAIL Current ccComplete"
+                    "Condition": "PLAYER_FARMHOUSE_UPGRADE Current 1, PLAYER_HAS_MAIL Current ccIsComplete"
                 }
             },
             "MoveEntries": [


### PR DESCRIPTION
The condition for adding cooking chocolate to Pierre's was the player having `ccComplete` mail flag set (community center completed.) This merge replaces the flag with `ccIsComplete` which correctly checks for the community center mail.

[Relevant documentation](https://stardewvalleywiki.com/Modding:Mail_data#Mail_flags)