### PR TITLE
Add an event for post cook interaction

### DIFF
--- a/LoveOfCooking/Core/ModEntry.cs
+++ b/LoveOfCooking/Core/ModEntry.cs
@@ -14,782 +14,783 @@ using StardewValley.Menus;
 
 namespace LoveOfCooking
 {
-	public class ModEntry : Mod
-	{
-		public static ModEntry Instance;
-		public static Config Config;
-		public static Texture2D SpriteSheet;
-		public static ICookingSkillAPI CookingSkillApi;
+    public class ModEntry : Mod
+    {
+        public static ModEntry Instance;
+        public static Config Config;
+        public static Texture2D SpriteSheet;
+        public static ICookingSkillAPI CookingSkillApi;
 
-		internal const string ContentModUniqueID = "blueberry.LoveOfCooking.CP"; // DO NOT EDIT
-		internal const string AssetPrefix = "blueberry.LoveOfCooking."; // DO NOT EDIT
-		internal const string ModDataPrefix = "blueberry.LoveOfCooking."; // DO NOT EDIT
-		internal const string ObjectPrefix = "blueberry.LoveOfCooking_"; // DO NOT EDIT
-		internal const string MailPrefix = "blueberry.LoveOfCooking."; // DO NOT EDIT
-		internal const string QueryPrefix = "BLUEBERRY_LOC_"; // DO NOT EDIT
-		internal const string CookbookItemId = ModEntry.ObjectPrefix + "cookbook"; // DO NOT EDIT
-		internal const string Seasoning1ItemId = ModEntry.ObjectPrefix + "seasoning_1"; // DO NOT EDIT
-		internal const string Seasoning2ItemId = ModEntry.ObjectPrefix + "seasoning_2"; // DO NOT EDIT
-		internal const string CookbookWalletId = ModEntry.ObjectPrefix + "cookbook"; // DO NOT EDIT
-		internal const string CurryBuffId = ModEntry.ObjectPrefix + "curry"; // DO NOT EDIT
-		internal const string KebabBuffId = ModEntry.ObjectPrefix + "kebab"; // DO NOT EDIT
-		internal const string LasagnaBuffId = ModEntry.ObjectPrefix + "lasagna"; // DO NOT EDIT
-		internal const string PaellaBuffId = ModEntry.ObjectPrefix + "paella"; // DO NOT EDIT
-		internal const string ProfiterolesBuffId = ModEntry.ObjectPrefix + "profiteroles"; // DO NOT EDIT
-		internal const string LeeksBuffId = ModEntry.ObjectPrefix + "leeks"; // DO NOT EDIT
-		internal static int SpriteId => (int)Game1.player.UniqueMultiplayerID + 5050505;
-		internal static int NexusId { get; private set; }
+        internal const string ContentModUniqueID = "blueberry.LoveOfCooking.CP"; // DO NOT EDIT
+        internal const string AssetPrefix = "blueberry.LoveOfCooking."; // DO NOT EDIT
+        internal const string ModDataPrefix = "blueberry.LoveOfCooking."; // DO NOT EDIT
+        internal const string ObjectPrefix = "blueberry.LoveOfCooking_"; // DO NOT EDIT
+        internal const string MailPrefix = "blueberry.LoveOfCooking."; // DO NOT EDIT
+        internal const string QueryPrefix = "BLUEBERRY_LOC_"; // DO NOT EDIT
+        internal const string CookbookItemId = ModEntry.ObjectPrefix + "cookbook"; // DO NOT EDIT
+        internal const string Seasoning1ItemId = ModEntry.ObjectPrefix + "seasoning_1"; // DO NOT EDIT
+        internal const string Seasoning2ItemId = ModEntry.ObjectPrefix + "seasoning_2"; // DO NOT EDIT
+        internal const string CookbookWalletId = ModEntry.ObjectPrefix + "cookbook"; // DO NOT EDIT
+        internal const string CurryBuffId = ModEntry.ObjectPrefix + "curry"; // DO NOT EDIT
+        internal const string KebabBuffId = ModEntry.ObjectPrefix + "kebab"; // DO NOT EDIT
+        internal const string LasagnaBuffId = ModEntry.ObjectPrefix + "lasagna"; // DO NOT EDIT
+        internal const string PaellaBuffId = ModEntry.ObjectPrefix + "paella"; // DO NOT EDIT
+        internal const string ProfiterolesBuffId = ModEntry.ObjectPrefix + "profiteroles"; // DO NOT EDIT
+        internal const string LeeksBuffId = ModEntry.ObjectPrefix + "leeks"; // DO NOT EDIT
+        internal static int SpriteId => (int)Game1.player.UniqueMultiplayerID + 5050505;
+        internal static int NexusId { get; private set; }
 
-		// Player session state
-		public readonly PerScreen<State> States = new(createNewState: () => new());
-		
-		// Mod data definitions
-		internal static Definitions Definitions;
+        // Player session state
+        public readonly PerScreen<State> States = new(createNewState: () => new());
 
-		// Others:
-		// base game reference
-		internal enum SkillIndex
-		{
-			Farming,
-			Fishing,
-			Foraging,
-			Mining,
-			Combat,
-			Luck
-		}
-		// cook at kitchens
-		internal static Dictionary<string, string> NpcHomeLocations = [];
+        // Mod data definitions
+        internal static Definitions Definitions;
 
-		// Mail titles
-		internal static readonly string MailCookbookUnlocked = MailPrefix + "cookbook_unlocked"; // DO NOT EDIT
-		internal static readonly string MailMigrateRefund16 = MailPrefix + "migrate_refund_1_6"; // DO NOT EDIT
-		internal static readonly string MailSeasoning1 = MailPrefix + "seasoning_1"; // DO NOT EDIT
-		internal static readonly string MailSeasoning2 = MailPrefix + "seasoning_2"; // DO NOT EDIT
+        // Others:
+        // base game reference
+        internal enum SkillIndex
+        {
+            Farming,
+            Fishing,
+            Foraging,
+            Mining,
+            Combat,
+            Luck
+        }
+        // cook at kitchens
+        internal static Dictionary<string, string> NpcHomeLocations = [];
 
-		// Mod features
-		internal static float DebugGlobalExperienceRate = 1f;
+        // Mail titles
+        internal static readonly string MailCookbookUnlocked = MailPrefix + "cookbook_unlocked"; // DO NOT EDIT
+        internal static readonly string MailMigrateRefund16 = MailPrefix + "migrate_refund_1_6"; // DO NOT EDIT
+        internal static readonly string MailSeasoning1 = MailPrefix + "seasoning_1"; // DO NOT EDIT
+        internal static readonly string MailSeasoning2 = MailPrefix + "seasoning_2"; // DO NOT EDIT
 
-		// Better Crafting
-		internal static Dictionary<string, IIngredient> BetterCraftingSeasonings = [];
+        // Mod features
+        internal static float DebugGlobalExperienceRate = 1f;
 
-		public override void Entry(IModHelper helper)
-		{
-			ModEntry.Instance = this;
-			ModEntry.Config = helper.ReadConfig<Config>();
-			ModEntry.NexusId = int.Parse(this.ModManifest.UpdateKeys
-				.First(s => s.StartsWith("nexus", StringComparison.InvariantCultureIgnoreCase))
-				.Split(':')
-				.Last());
-			this.PrintConfig();
+        // Better Crafting
+        internal static Dictionary<string, IIngredient> BetterCraftingSeasonings = [];
 
-			// Do not load mod if content component is not found
-			if (!helper.ModRegistry.IsLoaded(ModEntry.ContentModUniqueID))
-			{
-				Log.E($"Couldn't find required mod: {ModEntry.ContentModUniqueID}{Environment.NewLine}Please make sure all folders from LoveOfCooking ZIP file have been extracted to your Mods folder.");
-				Log.E($"{this.ModManifest.Name} failed to initialise. Mod may not be usable.");
-				return;
-			}
+        public override void Entry(IModHelper helper)
+        {
+            ModEntry.Instance = this;
+            ModEntry.Config = helper.ReadConfig<Config>();
+            ModEntry.NexusId = int.Parse(this.ModManifest.UpdateKeys
+                .First(s => s.StartsWith("nexus", StringComparison.InvariantCultureIgnoreCase))
+                .Split(':')
+                .Last());
+            this.PrintConfig();
 
-			this.Helper.Events.GameLoop.GameLaunched += this.GameLoop_GameLaunched;
-		}
+            // Do not load mod if content component is not found
+            if (!helper.ModRegistry.IsLoaded(ModEntry.ContentModUniqueID))
+            {
+                Log.E($"Couldn't find required mod: {ModEntry.ContentModUniqueID}{Environment.NewLine}Please make sure all folders from LoveOfCooking ZIP file have been extracted to your Mods folder.");
+                Log.E($"{this.ModManifest.Name} failed to initialise. Mod may not be usable.");
+                return;
+            }
 
-		public override object GetApi()
-		{
-			return new CookingSkillAPI(reflection: this.Helper.Reflection);
-		}
+            ModEntry.CookingSkillApi = new CookingSkillAPI(this.Helper.Reflection);
+            this.Helper.Events.GameLoop.GameLaunched += this.GameLoop_GameLaunched;
+        }
 
-		private void RegisterEvents()
-		{
-			// Translated strings are loaded from CP i18n file contents
-			LocalizedContentManager.OnLanguageChange += AssetManager.ReloadStrings;
+        public override object GetApi()
+        {
+            return CookingSkillApi;
+        }
 
-			// Game events
-			this.Helper.Events.Specialized.LoadStageChanged += this.Specialized_LoadStageChanged;
-			this.Helper.Events.Content.AssetRequested += AssetManager.OnAssetRequested;
-			this.Helper.Events.GameLoop.SaveLoaded += this.GameLoop_SaveLoaded;
-			this.Helper.Events.GameLoop.Saving += this.GameLoop_Saving;
-			this.Helper.Events.GameLoop.DayStarted += this.GameLoop_DayStarted;
-			this.Helper.Events.GameLoop.ReturnedToTitle += this.GameLoop_ReturnedToTitle;
-			this.Helper.Events.Input.ButtonPressed += this.Input_ButtonPressed;
-			this.Helper.Events.Display.MenuChanged += this.Display_MenuChanged;
-			this.Helper.Events.Multiplayer.PeerContextReceived += this.Multiplayer_PeerContextReceived;
-			this.Helper.Events.Multiplayer.PeerConnected += this.Multiplayer_PeerConnected;
+        private void RegisterEvents()
+        {
+            // Translated strings are loaded from CP i18n file contents
+            LocalizedContentManager.OnLanguageChange += AssetManager.ReloadStrings;
 
-			// Cooking Animations
-			this.Helper.Events.Display.RenderedWorld += this.Event_DrawCookingAnimation;
+            // Game events
+            this.Helper.Events.Specialized.LoadStageChanged += this.Specialized_LoadStageChanged;
+            this.Helper.Events.Content.AssetRequested += AssetManager.OnAssetRequested;
+            this.Helper.Events.GameLoop.SaveLoaded += this.GameLoop_SaveLoaded;
+            this.Helper.Events.GameLoop.Saving += this.GameLoop_Saving;
+            this.Helper.Events.GameLoop.DayStarted += this.GameLoop_DayStarted;
+            this.Helper.Events.GameLoop.ReturnedToTitle += this.GameLoop_ReturnedToTitle;
+            this.Helper.Events.Input.ButtonPressed += this.Input_ButtonPressed;
+            this.Helper.Events.Display.MenuChanged += this.Display_MenuChanged;
+            this.Helper.Events.Multiplayer.PeerContextReceived += this.Multiplayer_PeerContextReceived;
+            this.Helper.Events.Multiplayer.PeerConnected += this.Multiplayer_PeerConnected;
 
-			// Food Heals Over Time
-			this.States.Value.Regeneration.RegisterEvents(helper: this.Helper);
+            // Cooking Animations
+            this.Helper.Events.Display.RenderedWorld += this.Event_DrawCookingAnimation;
 
-			SpaceEvents.OnItemEaten += this.SpaceEvents_ItemEaten;
-			SpaceEvents.AfterGiftGiven += this.SpaceEvents_AfterGiftGiven;
+            // Food Heals Over Time
+            this.States.Value.Regeneration.RegisterEvents(helper: this.Helper);
 
-			if (Interfaces.BetterCraftingApi is IBetterCrafting betterCrafting)
-			{
-				betterCrafting.ApplySeasoning += this.BetterCrafting_ApplySeasoning;
-				betterCrafting.CheckCanCraft += this.BetterCrafting_CheckCanCraft;
-				betterCrafting.PostCraft += this.BetterCrafting_PostCraft;
-			}
-		}
+            SpaceEvents.OnItemEaten += this.SpaceEvents_ItemEaten;
+            SpaceEvents.AfterGiftGiven += this.SpaceEvents_AfterGiftGiven;
 
-		private void AddConsoleCommands()
-		{
-			string cmd = ModEntry.Definitions.ConsoleCommandPrefix;
+            if (Interfaces.BetterCraftingApi is IBetterCrafting betterCrafting)
+            {
+                betterCrafting.ApplySeasoning += this.BetterCrafting_ApplySeasoning;
+                betterCrafting.CheckCanCraft += this.BetterCrafting_CheckCanCraft;
+                betterCrafting.PostCraft += this.BetterCrafting_PostCraft;
+            }
+        }
 
-			IEnumerable<string> forgetLoveOfCookingRecipes() {
-				IEnumerable<string> recipes = CookingSkillApi.GetAllLoveOfCookingRecipes();
-				foreach (string recipe in recipes)
-				{
-					Game1.player.cookingRecipes.Remove(recipe);
-				}
-				return recipes;
-			}
+        private void AddConsoleCommands()
+        {
+            string cmd = ModEntry.Definitions.ConsoleCommandPrefix;
 
-			string listKnownCookingRecipes()
-			{
-				return Game1.player.cookingRecipes.Keys
-					.OrderBy(s => s)
-					.Aggregate("Cooking recipes:", (cur, s) => $"{cur}{Environment.NewLine}{s}");
-			}
+            IEnumerable<string> forgetLoveOfCookingRecipes()
+            {
+                IEnumerable<string> recipes = CookingSkillApi.GetAllLoveOfCookingRecipes();
+                foreach (string recipe in recipes)
+                {
+                    Game1.player.cookingRecipes.Remove(recipe);
+                }
+                return recipes;
+            }
 
-			this.Helper.ConsoleCommands.Add(
-				name: cmd + "set_cooking_level",
-				documentation: "Set cooking level.",
-				callback: (s, args) =>
-				{
-					if (!ModEntry.Config.AddCookingSkillAndRecipes)
-					{
-						Log.D("Cooking skill is not enabled.");
-						return;
-					}
-					if (args.Length < 1)
-					{
-						Log.D($"Choose a level between 0 and {ModEntry.CookingSkillApi.GetMaximumLevel()}.");
-						return;
-					}
+            string listKnownCookingRecipes()
+            {
+                return Game1.player.cookingRecipes.Keys
+                    .OrderBy(s => s)
+                    .Aggregate("Cooking recipes:", (cur, s) => $"{cur}{Environment.NewLine}{s}");
+            }
 
-					// Update experience
-					this.Helper.Reflection.GetProperty
-						<Dictionary<long, Dictionary<string, int>>>
-						(typeof(SpaceCore.Skills), "Exp")
-						.GetValue()
-						[Game1.player.UniqueMultiplayerID][CookingSkill.InternalName] = 0;
+            this.Helper.ConsoleCommands.Add(
+                name: cmd + "set_cooking_level",
+                documentation: "Set cooking level.",
+                callback: (s, args) =>
+                {
+                    if (!ModEntry.Config.AddCookingSkillAndRecipes)
+                    {
+                        Log.D("Cooking skill is not enabled.");
+                        return;
+                    }
+                    if (args.Length < 1)
+                    {
+                        Log.D($"Choose a level between 0 and {ModEntry.CookingSkillApi.GetMaximumLevel()}.");
+                        return;
+                    }
 
-					// Reset recipes
-					forgetLoveOfCookingRecipes();
+                    // Update experience
+                    this.Helper.Reflection.GetProperty
+                        <Dictionary<long, Dictionary<string, int>>>
+                        (typeof(SpaceCore.Skills), "Exp")
+                        .GetValue()
+                        [Game1.player.UniqueMultiplayerID][CookingSkill.InternalName] = 0;
 
-					// Add to current level
-					int level = CookingSkillApi.GetLevel();
-					int target = Math.Min(10, level + int.Parse(args[0]));
-					CookingSkillApi.AddExperienceDirectly(
-						CookingSkillApi.GetTotalExperienceRequiredForLevel(target)
-						- CookingSkillApi.GetTotalCurrentExperience());
+                    // Reset recipes
+                    forgetLoveOfCookingRecipes();
 
-					// Update professions
-					foreach (SpaceCore.Skills.Skill.Profession profession in CookingSkillApi.GetSkill().Professions)
-						if (Game1.player.professions.Contains(profession.GetVanillaId()))
-							Game1.player.professions.Remove(profession.GetVanillaId());
+                    // Add to current level
+                    int level = CookingSkillApi.GetLevel();
+                    int target = Math.Min(10, level + int.Parse(args[0]));
+                    CookingSkillApi.AddExperienceDirectly(
+                        CookingSkillApi.GetTotalExperienceRequiredForLevel(target)
+                        - CookingSkillApi.GetTotalCurrentExperience());
 
-					Log.D($"Set Cooking skill to {CookingSkillApi.GetLevel()}");
-				});
-			this.Helper.ConsoleCommands.Add(
-				name: cmd + "set_tool_level",
-				documentation: "Set cooking tool level.",
-				callback: (s, args) =>
-				{
-					if (!Config.AddCookingToolProgression)
-					{
-						Log.D("Cooking tool is not enabled.");
-						return;
-					}
-					if (args.Length < 1)
-						return;
+                    // Update professions
+                    foreach (SpaceCore.Skills.Skill.Profession profession in CookingSkillApi.GetSkill().Professions)
+                        if (Game1.player.professions.Contains(profession.GetVanillaId()))
+                            Game1.player.professions.Remove(profession.GetVanillaId());
 
-					this.States.Value.CookingToolLevel = int.Parse(args[0]);
-					Log.D($"Set Cooking tool to {this.States.Value.CookingToolLevel}");
-				});
-			this.Helper.ConsoleCommands.Add(
-				name: cmd + "hurt_me",
-				documentation: "Set current health and stamina to a given value. Pass zero, one, or two values.",
-				callback: (s, args) =>
-				{
-					if (args.Length < 1)
-					{
-						Game1.player.health = Game1.player.maxHealth / 10;
-						Game1.player.Stamina = Game1.player.MaxStamina / 10;
-					}
-					else
-					{
-						Game1.player.health = int.Parse(args[0]);
-						Game1.player.Stamina = args.Length < 2 ? Game1.player.health * 2.5f : int.Parse(args[1]);
-					}
-					Log.D($"Set HP: {Game1.player.health}, EP: {Game1.player.Stamina}");
-				});
-			this.Helper.ConsoleCommands.Add(
-				name: cmd + "forget_cooking_skill_recipes",
-				documentation: "Forget all unlocked Cooking Skill recipes until the next level-up.",
-				callback: (s, args) =>
-				{
-					string message;
-					IEnumerable<string> recipes = forgetLoveOfCookingRecipes();
-					message = $"Forgetting recipes added by Love of Cooking:{Environment.NewLine}" + string.Join(Environment.NewLine, recipes);
+                    Log.D($"Set Cooking skill to {CookingSkillApi.GetLevel()}");
+                });
+            this.Helper.ConsoleCommands.Add(
+                name: cmd + "set_tool_level",
+                documentation: "Set cooking tool level.",
+                callback: (s, args) =>
+                {
+                    if (!Config.AddCookingToolProgression)
+                    {
+                        Log.D("Cooking tool is not enabled.");
+                        return;
+                    }
+                    if (args.Length < 1)
+                        return;
 
-					message = listKnownCookingRecipes();
-					Log.D(message);
-				});
-			this.Helper.ConsoleCommands.Add(
-				name: cmd + "forget_invalid_recipes",
-				documentation: "Forget all invalid player recipes.",
-				callback: (s, args) =>
-				{
-					string message;
-					var validRecipes = Game1.content.Load<Dictionary<string, string>>("Data/CookingRecipes");
-					List<string> invalidRecipes = Game1.player.cookingRecipes.Keys
-						.Where(key => !validRecipes.ContainsKey(key))
-						.ToList();
+                    this.States.Value.CookingToolLevel = int.Parse(args[0]);
+                    Log.D($"Set Cooking tool to {this.States.Value.CookingToolLevel}");
+                });
+            this.Helper.ConsoleCommands.Add(
+                name: cmd + "hurt_me",
+                documentation: "Set current health and stamina to a given value. Pass zero, one, or two values.",
+                callback: (s, args) =>
+                {
+                    if (args.Length < 1)
+                    {
+                        Game1.player.health = Game1.player.maxHealth / 10;
+                        Game1.player.Stamina = Game1.player.MaxStamina / 10;
+                    }
+                    else
+                    {
+                        Game1.player.health = int.Parse(args[0]);
+                        Game1.player.Stamina = args.Length < 2 ? Game1.player.health * 2.5f : int.Parse(args[1]);
+                    }
+                    Log.D($"Set HP: {Game1.player.health}, EP: {Game1.player.Stamina}");
+                });
+            this.Helper.ConsoleCommands.Add(
+                name: cmd + "forget_cooking_skill_recipes",
+                documentation: "Forget all unlocked Cooking Skill recipes until the next level-up.",
+                callback: (s, args) =>
+                {
+                    string message;
+                    IEnumerable<string> recipes = forgetLoveOfCookingRecipes();
+                    message = $"Forgetting recipes added by Love of Cooking:{Environment.NewLine}" + string.Join(Environment.NewLine, recipes);
 
-					message = $"Forgetting invalid recipes:{Environment.NewLine}" + string.Join(Environment.NewLine, invalidRecipes);
-					Log.D(message);
+                    message = listKnownCookingRecipes();
+                    Log.D(message);
+                });
+            this.Helper.ConsoleCommands.Add(
+                name: cmd + "forget_invalid_recipes",
+                documentation: "Forget all invalid player recipes.",
+                callback: (s, args) =>
+                {
+                    string message;
+                    var validRecipes = Game1.content.Load<Dictionary<string, string>>("Data/CookingRecipes");
+                    List<string> invalidRecipes = Game1.player.cookingRecipes.Keys
+                        .Where(key => !validRecipes.ContainsKey(key))
+                        .ToList();
 
-					foreach (string recipe in invalidRecipes)
-					{
-						Game1.player.cookingRecipes.Remove(recipe);
-					}
+                    message = $"Forgetting invalid recipes:{Environment.NewLine}" + string.Join(Environment.NewLine, invalidRecipes);
+                    Log.D(message);
 
-					message = listKnownCookingRecipes();
-					Log.D(message);
-				});
-			this.Helper.ConsoleCommands.Add(
-				name: cmd + "give_cookbook",
-				documentation: "Adds Cookbook and Frying Pan to your Special Items, allowing kitchens to be used and frying pans to be upgraded.",
-				callback: (s, args) =>
-				{
-					Utils.PlayCookbookReceivedSequence();
-					Log.D($"Added Cookbook and Frying Pan to your Special Items.");
-				});
-			this.Helper.ConsoleCommands.Add(
-				name: cmd + "unstuck_me",
-				documentation: "Unlocks player movement if stuck in animations.",
-				callback: (s, args) =>
-				{
-					if (Game1.activeClickableMenu is CookingMenu)
-					{
-						Game1.activeClickableMenu.emergencyShutDown();
-					}
-					Game1.player.Halt();
-					Game1.player.completelyStopAnimatingOrDoingAction();
-					Game1.player.faceDirection(2);
-					Game1.player.Position = Game1.tileSize * Utility.recursiveFindOpenTileForCharacter(
-						c: Game1.player,
-						l: Game1.currentLocation,
-						tileLocation: Game1.player.Tile,
-						maxIterations: 10);
-					Game1.freezeControls = false;
-				});
-			this.Helper.ConsoleCommands.Add(
-				name: cmd + "print_recipes",
-				documentation: "Show all unlocked player recipes.",
-				callback: (s, args) =>
-				{
-					string message = Game1.player.cookingRecipes.Keys.OrderBy(str => str)
-						.Aggregate("Cooking recipes:", (cur, str) => $"{cur}{Environment.NewLine}{str}");
-					Log.D(message);
-				});
-			this.Helper.ConsoleCommands.Add(
-				name: cmd + "print_config",
-				documentation: "Print config state.",
-				callback: (s, args) =>
-				{
-					this.PrintConfig();
-				});
-			this.Helper.ConsoleCommands.Add(
-				name: cmd + "print_data",
-				documentation: "Print save data state.",
-				callback: (s, args) =>
-				{
-					this.PrintModData();
-				});
-			this.Helper.ConsoleCommands.Add(
-				name: cmd + "print_skill",
-				documentation: "Print skill state.",
-				callback: (s, args) =>
-				{
-					this.PrintCookingSkill();
-				});
-			this.Helper.ConsoleCommands.Add(
-				name: cmd + "print",
-				documentation: "Print all mod info.",
-				callback: (s, args) =>
-				{
-					this.PrintConfig();
-					this.PrintModData();
-					this.PrintCookingSkill();
-				});
-		}
+                    foreach (string recipe in invalidRecipes)
+                    {
+                        Game1.player.cookingRecipes.Remove(recipe);
+                    }
 
-		private void GameLoop_GameLaunched(object sender, GameLaunchedEventArgs e)
-		{
-			if (this.Init())
-			{
-				this.Helper.Events.GameLoop.OneSecondUpdateTicked += this.GameLoop_OneSecondUpdateTicked_LoadLate;
-			}
-		}
+                    message = listKnownCookingRecipes();
+                    Log.D(message);
+                });
+            this.Helper.ConsoleCommands.Add(
+                name: cmd + "give_cookbook",
+                documentation: "Adds Cookbook and Frying Pan to your Special Items, allowing kitchens to be used and frying pans to be upgraded.",
+                callback: (s, args) =>
+                {
+                    Utils.PlayCookbookReceivedSequence();
+                    Log.D($"Added Cookbook and Frying Pan to your Special Items.");
+                });
+            this.Helper.ConsoleCommands.Add(
+                name: cmd + "unstuck_me",
+                documentation: "Unlocks player movement if stuck in animations.",
+                callback: (s, args) =>
+                {
+                    if (Game1.activeClickableMenu is CookingMenu)
+                    {
+                        Game1.activeClickableMenu.emergencyShutDown();
+                    }
+                    Game1.player.Halt();
+                    Game1.player.completelyStopAnimatingOrDoingAction();
+                    Game1.player.faceDirection(2);
+                    Game1.player.Position = Game1.tileSize * Utility.recursiveFindOpenTileForCharacter(
+                        c: Game1.player,
+                        l: Game1.currentLocation,
+                        tileLocation: Game1.player.Tile,
+                        maxIterations: 10);
+                    Game1.freezeControls = false;
+                });
+            this.Helper.ConsoleCommands.Add(
+                name: cmd + "print_recipes",
+                documentation: "Show all unlocked player recipes.",
+                callback: (s, args) =>
+                {
+                    string message = Game1.player.cookingRecipes.Keys.OrderBy(str => str)
+                        .Aggregate("Cooking recipes:", (cur, str) => $"{cur}{Environment.NewLine}{str}");
+                    Log.D(message);
+                });
+            this.Helper.ConsoleCommands.Add(
+                name: cmd + "print_config",
+                documentation: "Print config state.",
+                callback: (s, args) =>
+                {
+                    this.PrintConfig();
+                });
+            this.Helper.ConsoleCommands.Add(
+                name: cmd + "print_data",
+                documentation: "Print save data state.",
+                callback: (s, args) =>
+                {
+                    this.PrintModData();
+                });
+            this.Helper.ConsoleCommands.Add(
+                name: cmd + "print_skill",
+                documentation: "Print skill state.",
+                callback: (s, args) =>
+                {
+                    this.PrintCookingSkill();
+                });
+            this.Helper.ConsoleCommands.Add(
+                name: cmd + "print",
+                documentation: "Print all mod info.",
+                callback: (s, args) =>
+                {
+                    this.PrintConfig();
+                    this.PrintModData();
+                    this.PrintCookingSkill();
+                });
+        }
 
-		private void GameLoop_OneSecondUpdateTicked_LoadLate(object sender, OneSecondUpdateTickedEventArgs e)
-		{
-			this.Helper.Events.GameLoop.OneSecondUpdateTicked -= this.GameLoop_OneSecondUpdateTicked_LoadLate;
-			this.InitLate();
-		}
+        private void GameLoop_GameLaunched(object sender, GameLaunchedEventArgs e)
+        {
+            if (this.Init())
+            {
+                this.Helper.Events.GameLoop.OneSecondUpdateTicked += this.GameLoop_OneSecondUpdateTicked_LoadLate;
+            }
+        }
 
-		private void Specialized_LoadStageChanged(object sender, LoadStageChangedEventArgs e)
-		{
-			if (e.NewStage is StardewModdingAPI.Enums.LoadStage.Ready)
-			{
-				this.States.Value.Reset();
-				this.States.Value.Load(data: Game1.player.modData);
+        private void GameLoop_OneSecondUpdateTicked_LoadLate(object sender, OneSecondUpdateTickedEventArgs e)
+        {
+            this.Helper.Events.GameLoop.OneSecondUpdateTicked -= this.GameLoop_OneSecondUpdateTicked_LoadLate;
+            this.InitLate();
+        }
 
-				// Invalidate and reload assets
-				Log.D("Invalidating assets on LoadStageChanged.",
-					Config.DebugMode);
-				this.ReloadAssets();
-				AssetManager.InvalidateAssets();
-			}
-		}
+        private void Specialized_LoadStageChanged(object sender, LoadStageChangedEventArgs e)
+        {
+            if (e.NewStage is StardewModdingAPI.Enums.LoadStage.Ready)
+            {
+                this.States.Value.Reset();
+                this.States.Value.Load(data: Game1.player.modData);
 
-		private void GameLoop_SaveLoaded(object sender, SaveLoadedEventArgs e)
-		{
-			this.PrintModData();
-			this.PrintCookingSkill();
-		}
+                // Invalidate and reload assets
+                Log.D("Invalidating assets on LoadStageChanged.",
+                    Config.DebugMode);
+                this.ReloadAssets();
+                AssetManager.InvalidateAssets();
+            }
+        }
 
-		private void GameLoop_Saving(object sender, SavingEventArgs e)
-		{
-			this.States.Value.Save(data: Game1.player.modData);
-		}
+        private void GameLoop_SaveLoaded(object sender, SaveLoadedEventArgs e)
+        {
+            this.PrintModData();
+            this.PrintCookingSkill();
+        }
 
-		private void GameLoop_DayStarted(object sender, DayStartedEventArgs e)
-		{
-			// Cooking Skill
-			// Clear daily cooking to free up experience gains
-			ModEntry.Instance.States.Value.FoodCookedToday.Clear();
+        private void GameLoop_Saving(object sender, SavingEventArgs e)
+        {
+            this.States.Value.Save(data: Game1.player.modData);
+        }
 
-			// Migration
-			Utils.CleanUpSaveFiles();
+        private void GameLoop_DayStarted(object sender, DayStartedEventArgs e)
+        {
+            // Cooking Skill
+            // Clear daily cooking to free up experience gains
+            ModEntry.Instance.States.Value.FoodCookedToday.Clear();
 
-			// Food Heals Over Time
-			this.States.Value.Regeneration.UpdateDefinitions();
+            // Migration
+            Utils.CleanUpSaveFiles();
 
-			// Cooking Menu
-			Utils.TryAddCookbook(who: Game1.player);
+            // Food Heals Over Time
+            this.States.Value.Regeneration.UpdateDefinitions();
 
-			// More Seasonings
-			Utils.TrySendSeasoningRecipes(who: Game1.player);
-		}
+            // Cooking Menu
+            Utils.TryAddCookbook(who: Game1.player);
 
-		private void GameLoop_ReturnedToTitle(object sender, ReturnedToTitleEventArgs e)
-		{
-			// Reset session state
-			this.States.Value.Reset();
-		}
+            // More Seasonings
+            Utils.TrySendSeasoningRecipes(who: Game1.player);
+        }
 
-		[EventPriority(EventPriority.Low)]
-		private void Event_DrawCookingAnimation(object sender, RenderedWorldEventArgs e)
-		{
-			if (!Context.IsWorldReady || Game1.currentLocation is null)
-				return;
+        private void GameLoop_ReturnedToTitle(object sender, ReturnedToTitleEventArgs e)
+        {
+            // Reset session state
+            this.States.Value.Reset();
+        }
 
-			// Draw cooking animation sprites
-			Game1.currentLocation.getTemporarySpriteByID(ModEntry.SpriteId)?.draw(
-				e.SpriteBatch,
-				localPosition: false,
-				xOffset: 0,
-				yOffset: 0,
-				extraAlpha: 1f);
-		}
-		
-		private void Input_ButtonPressed(object sender, ButtonPressedEventArgs e)
-		{
-			if (Utils.PlayerAgencyLostCheck() || Game1.activeClickableMenu is not null || !Game1.player.CanMove)
-				return;
+        [EventPriority(EventPriority.Low)]
+        private void Event_DrawCookingAnimation(object sender, RenderedWorldEventArgs e)
+        {
+            if (!Context.IsWorldReady || Game1.currentLocation is null)
+                return;
 
-			if (e.Button.IsActionButton())
-			{
-				// Open cooking menus from available kitchen tiles
-				if (ModEntry.Config.CanUseTownKitchens && Utils.CanUseKitchens(who: Game1.player)
-					&& Utils.IsKitchenTileUnderCursor(location: Game1.currentLocation, point: e.Cursor.GrabTile.ToPoint(), who: Game1.player, out string friendshipLockedBy))
-				{
-					if (friendshipLockedBy is null)
-					{
-						Utils.TryOpenNewCookingMenu();
-					}
-					else
-					{
-						string name = ModEntry.NpcHomeLocations.FirstOrDefault(pair => pair.Value == Game1.currentLocation.Name).Key;
-						NPC npc = Game1.getCharacterFromName(name);
-						Game1.drawDialogueNoTyping(Strings.Get("menu.cooking_station.no_friendship", npc.displayName));
-					}
-					this.Helper.Input.Suppress(e.Button);
-					return;
-				}
-			}
-		}
+            // Draw cooking animation sprites
+            Game1.currentLocation.getTemporarySpriteByID(ModEntry.SpriteId)?.draw(
+                e.SpriteBatch,
+                localPosition: false,
+                xOffset: 0,
+                yOffset: 0,
+                extraAlpha: 1f);
+        }
 
-		[EventPriority(EventPriority.Low)]
-		private void Display_MenuChanged(object sender, MenuChangedEventArgs e)
-		{
-			if (e.OldMenu is TitleMenu || e.NewMenu is TitleMenu || !Context.IsWorldReady || Game1.currentLocation is null || Game1.player is null)
-				return;
+        private void Input_ButtonPressed(object sender, ButtonPressedEventArgs e)
+        {
+            if (Utils.PlayerAgencyLostCheck() || Game1.activeClickableMenu is not null || !Game1.player.CanMove)
+                return;
 
-			if (e.NewMenu is null)
-			{
-				// Unlock any existing mutexes from this player
-				ModEntry.Instance.States.Value.MenuMutex?.ReleaseLocks();
-			}
-		}
+            if (e.Button.IsActionButton())
+            {
+                // Open cooking menus from available kitchen tiles
+                if (ModEntry.Config.CanUseTownKitchens && Utils.CanUseKitchens(who: Game1.player)
+                    && Utils.IsKitchenTileUnderCursor(location: Game1.currentLocation, point: e.Cursor.GrabTile.ToPoint(), who: Game1.player, out string friendshipLockedBy))
+                {
+                    if (friendshipLockedBy is null)
+                    {
+                        Utils.TryOpenNewCookingMenu();
+                    }
+                    else
+                    {
+                        string name = ModEntry.NpcHomeLocations.FirstOrDefault(pair => pair.Value == Game1.currentLocation.Name).Key;
+                        NPC npc = Game1.getCharacterFromName(name);
+                        Game1.drawDialogueNoTyping(Strings.Get("menu.cooking_station.no_friendship", npc.displayName));
+                    }
+                    this.Helper.Input.Suppress(e.Button);
+                    return;
+                }
+            }
+        }
 
-		private void Multiplayer_PeerContextReceived(object sender, PeerContextReceivedEventArgs e)
-		{
-			if (!Context.IsMainPlayer)
-				return;
-			Log.D($"Peer context received: {e.Peer.PlayerID} : SMAPI:{e.Peer.HasSmapi}" +
-				$" CAC:{(e.Peer.Mods?.ToList().FirstOrDefault(mod => mod.ID == this.Helper.ModRegistry.ModID) is IMultiplayerPeerMod mod && mod is not null ? mod.Version.ToString() : "null")}",
-				Config.DebugMode);
-		}
+        [EventPriority(EventPriority.Low)]
+        private void Display_MenuChanged(object sender, MenuChangedEventArgs e)
+        {
+            if (e.OldMenu is TitleMenu || e.NewMenu is TitleMenu || !Context.IsWorldReady || Game1.currentLocation is null || Game1.player is null)
+                return;
 
-		private void Multiplayer_PeerConnected(object sender, PeerConnectedEventArgs e)
-		{
-			if (!Context.IsMainPlayer)
-				return;
-			Log.D($"Peer connected to multiplayer session: {e.Peer.PlayerID} : SMAPI:{e.Peer.HasSmapi}" +
-				$" CAC:{(e.Peer.Mods?.ToList().FirstOrDefault(mod => mod.ID == this.Helper.ModRegistry.ModID) is IMultiplayerPeerMod mod && mod is not null ? mod.Version.ToString() : "null")}",
-				Config.DebugMode);
-		}
+            if (e.NewMenu is null)
+            {
+                // Unlock any existing mutexes from this player
+                ModEntry.Instance.States.Value.MenuMutex?.ReleaseLocks();
+            }
+        }
 
-		private void SpaceEvents_ItemEaten(object sender, EventArgs e)
-		{
-			Farmer who = Game1.player;
+        private void Multiplayer_PeerContextReceived(object sender, PeerContextReceivedEventArgs e)
+        {
+            if (!Context.IsMainPlayer)
+                return;
+            Log.D($"Peer context received: {e.Peer.PlayerID} : SMAPI:{e.Peer.HasSmapi}" +
+                $" CAC:{(e.Peer.Mods?.ToList().FirstOrDefault(mod => mod.ID == this.Helper.ModRegistry.ModID) is IMultiplayerPeerMod mod && mod is not null ? mod.Version.ToString() : "null")}",
+                Config.DebugMode);
+        }
 
-			// Don't consider excluded items for food behaviours, e.g. Food Heals Over Time
-			if (who.itemToEat is not StardewValley.Object food
+        private void Multiplayer_PeerConnected(object sender, PeerConnectedEventArgs e)
+        {
+            if (!Context.IsMainPlayer)
+                return;
+            Log.D($"Peer connected to multiplayer session: {e.Peer.PlayerID} : SMAPI:{e.Peer.HasSmapi}" +
+                $" CAC:{(e.Peer.Mods?.ToList().FirstOrDefault(mod => mod.ID == this.Helper.ModRegistry.ModID) is IMultiplayerPeerMod mod && mod is not null ? mod.Version.ToString() : "null")}",
+                Config.DebugMode);
+        }
+
+        private void SpaceEvents_ItemEaten(object sender, EventArgs e)
+        {
+            Farmer who = Game1.player;
+
+            // Don't consider excluded items for food behaviours, e.g. Food Heals Over Time
+            if (who.itemToEat is not StardewValley.Object food
                 || food.Edibility <= 0
                 || ModEntry.Definitions.EdibleItemsWithNoFoodBehaviour.Contains(who.itemToEat.Name))
-				return;
+                return;
 
-			if (food.ItemId == ModEntry.CookbookItemId)
-			{
-				// Whoops
-				// Yes, it's come up before
-				Utils.PlayCookbookReceivedSequence();
-			}
+            if (food.ItemId == ModEntry.CookbookItemId)
+            {
+                // Whoops
+                // Yes, it's come up before
+                Utils.PlayCookbookReceivedSequence();
+            }
 
-			// Determine food healing
-			if (ModEntry.Config.FoodHealingTakesTime)
-			{
-				this.States.Value.Regeneration.Eat(food: food);
-			}
-			else if (ModEntry.CookingSkillApi.HasProfession(ICookingSkillAPI.Profession.Restoration))
-			{
-				// Add additional health
-				who.health = (int) Math.Min(who.maxHealth,
-					who.health + food.healthRecoveredOnConsumption() * (ModEntry.Definitions.CookingSkillValues.RestorationAltValue / 100f));
-				who.Stamina = (int) Math.Min(who.MaxStamina,
-					who.Stamina + food.staminaRecoveredOnConsumption() * (ModEntry.Definitions.CookingSkillValues.RestorationAltValue / 100f));
-			}
+            // Determine food healing
+            if (ModEntry.Config.FoodHealingTakesTime)
+            {
+                this.States.Value.Regeneration.Eat(food: food);
+            }
+            else if (ModEntry.CookingSkillApi.HasProfession(ICookingSkillAPI.Profession.Restoration))
+            {
+                // Add additional health
+                who.health = (int)Math.Min(who.maxHealth,
+                    who.health + food.healthRecoveredOnConsumption() * (ModEntry.Definitions.CookingSkillValues.RestorationAltValue / 100f));
+                who.Stamina = (int)Math.Min(who.MaxStamina,
+                    who.Stamina + food.staminaRecoveredOnConsumption() * (ModEntry.Definitions.CookingSkillValues.RestorationAltValue / 100f));
+            }
 
-			// Check to boost buff duration
-			if (ModEntry.CookingSkillApi.HasProfession(ICookingSkillAPI.Profession.BuffDuration)
-			    && who.buffs.AppliedBuffs.TryGetValue(food.Name, out Buff foodBuff))
-			{
-				int duration = foodBuff.millisecondsDuration;
-				if (duration > 0)
-				{
-					float rate = (who.health + who.Stamina) / (who.maxHealth + who.MaxStamina);
-					duration += (int) Math.Floor(ModEntry.Definitions.CookingSkillValues.BuffDurationValue * 1000 * rate);
-					foodBuff.millisecondsDuration = duration;
-				}
-			}
+            // Check to boost buff duration
+            if (ModEntry.CookingSkillApi.HasProfession(ICookingSkillAPI.Profession.BuffDuration)
+                && who.buffs.AppliedBuffs.TryGetValue(food.Name, out Buff foodBuff))
+            {
+                int duration = foodBuff.millisecondsDuration;
+                if (duration > 0)
+                {
+                    float rate = (who.health + who.Stamina) / (who.maxHealth + who.MaxStamina);
+                    duration += (int)Math.Floor(ModEntry.Definitions.CookingSkillValues.BuffDurationValue * 1000 * rate);
+                    foodBuff.millisecondsDuration = duration;
+                }
+            }
 
-			// Check for unique buffs
-			if (food.GetFoodOrDrinkBuffs().FirstOrDefault(buff => buff.id == ModEntry.CurryBuffId) is Buff curry)
-			{
-				// curry
-				who.buffs.Remove(curry.id);
-				who.buffs.Apply(new CurryBuff(buff: curry));
-			}
-			else if (food.GetFoodOrDrinkBuffs().FirstOrDefault(buff => buff.id == ModEntry.LasagnaBuffId) is Buff lasagna)
-			{
-				// lasagna
-				who.buffs.Remove(lasagna.id);
-				who.buffs.Apply(new LasagnaBuff(buff: lasagna));
-			}
-			else if (food.GetFoodOrDrinkBuffs().FirstOrDefault(buff => buff.id == ModEntry.KebabBuffId) is Buff kebab1
-				&& who.buffs.AppliedBuffs.TryGetValue(Buff.tipsy, out Buff tipsy1))
-			{
-				// kebab (tipsy already active)
-				Utils.ApplyKebabBuffUpgrade(who: who, buff: kebab1);
-				who.buffs.Apply(kebab1); // Required to upgrade initial buff
-			}
-			else if (food.GetFoodOrDrinkBuffs().FirstOrDefault(buff => buff.id == Buff.tipsy) is Buff tipsy2
-				&& who.buffs.AppliedBuffs.TryGetValue(ModEntry.KebabBuffId, out Buff kebab2))
-			{
-				// tipsy (kebab already active)
-				Utils.ApplyKebabBuffUpgrade(who: who, buff: kebab2);
-			}
-			else if (food.GetFoodOrDrinkBuffs().FirstOrDefault(buff => buff.id == ModEntry.LeeksBuffId) is Buff leeks)
-			{
-				// leeks
-				leeks.effects.KnockbackMultiplier.Value = ModEntry.Definitions.LeeksBuffKnockbackMultiplier;
-				who.buffs.Remove(leeks.id);
-				who.buffs.Apply(leeks);
-			}
+            // Check for unique buffs
+            if (food.GetFoodOrDrinkBuffs().FirstOrDefault(buff => buff.id == ModEntry.CurryBuffId) is Buff curry)
+            {
+                // curry
+                who.buffs.Remove(curry.id);
+                who.buffs.Apply(new CurryBuff(buff: curry));
+            }
+            else if (food.GetFoodOrDrinkBuffs().FirstOrDefault(buff => buff.id == ModEntry.LasagnaBuffId) is Buff lasagna)
+            {
+                // lasagna
+                who.buffs.Remove(lasagna.id);
+                who.buffs.Apply(new LasagnaBuff(buff: lasagna));
+            }
+            else if (food.GetFoodOrDrinkBuffs().FirstOrDefault(buff => buff.id == ModEntry.KebabBuffId) is Buff kebab1
+                && who.buffs.AppliedBuffs.TryGetValue(Buff.tipsy, out Buff tipsy1))
+            {
+                // kebab (tipsy already active)
+                Utils.ApplyKebabBuffUpgrade(who: who, buff: kebab1);
+                who.buffs.Apply(kebab1); // Required to upgrade initial buff
+            }
+            else if (food.GetFoodOrDrinkBuffs().FirstOrDefault(buff => buff.id == Buff.tipsy) is Buff tipsy2
+                && who.buffs.AppliedBuffs.TryGetValue(ModEntry.KebabBuffId, out Buff kebab2))
+            {
+                // tipsy (kebab already active)
+                Utils.ApplyKebabBuffUpgrade(who: who, buff: kebab2);
+            }
+            else if (food.GetFoodOrDrinkBuffs().FirstOrDefault(buff => buff.id == ModEntry.LeeksBuffId) is Buff leeks)
+            {
+                // leeks
+                leeks.effects.KnockbackMultiplier.Value = ModEntry.Definitions.LeeksBuffKnockbackMultiplier;
+                who.buffs.Remove(leeks.id);
+                who.buffs.Apply(leeks);
+            }
 
-			// Track foods eaten
-			if (!this.States.Value.FoodsEaten.Contains(food.Name))
-			{
-				this.States.Value.FoodsEaten.Add(food.Name);
-			}
+            // Track foods eaten
+            if (!this.States.Value.FoodsEaten.Contains(food.Name))
+            {
+                this.States.Value.FoodsEaten.Add(food.Name);
+            }
 
-			// Add leftovers from viable foods to the inventory, or drop it on the ground if full
-			if (ModEntry.Definitions.FoodsThatGiveLeftovers.TryGetValue(food.Name, out string leftoversName))
-			{
-				Item leftovers = ItemRegistry.Create(itemId: leftoversName, amount: 1);
-				Utils.AddOrDropItem(leftovers);
-			}
-		}
+            // Add leftovers from viable foods to the inventory, or drop it on the ground if full
+            if (ModEntry.Definitions.FoodsThatGiveLeftovers.TryGetValue(food.Name, out string leftoversName))
+            {
+                Item leftovers = ItemRegistry.Create(itemId: leftoversName, amount: 1);
+                Utils.AddOrDropItem(leftovers);
+            }
+        }
 
-		private void SpaceEvents_AfterGiftGiven(object sender, EventArgsGiftGiven e)
-		{
-			// Cooking skill professions influence gift value of Cooking objects
-			if (CookingSkillApi.HasProfession(ICookingSkillAPI.Profession.GiftBoost) && e.Gift.Category == StardewValley.Object.CookingCategory)
-			{
-				Game1.player.changeFriendship(amount: ModEntry.Definitions.CookingSkillValues.GiftBoostValue, n: e.Npc);
-			}
-		}
+        private void SpaceEvents_AfterGiftGiven(object sender, EventArgsGiftGiven e)
+        {
+            // Cooking skill professions influence gift value of Cooking objects
+            if (CookingSkillApi.HasProfession(ICookingSkillAPI.Profession.GiftBoost) && e.Gift.Category == StardewValley.Object.CookingCategory)
+            {
+                Game1.player.changeFriendship(amount: ModEntry.Definitions.CookingSkillValues.GiftBoostValue, n: e.Npc);
+            }
+        }
 
-		private void BetterCrafting_CheckCanCraft(ICheckCanCraftEvent e)
-		{
-			if (ModEntry.Config.AddCookingToolProgression && e.IsCooking)
-			{
-				int level = CookingTool.GetEffectiveGlobalLevel();
-				int allowed = CookingTool.NumIngredientsAllowed(level: level);
-				int required = e.Recipe.Ingredients?.Length ?? 0;
-				string toolId = CookingTool.ToolID(level: level);
-				if (allowed < required)
-				{
-					string s = Strings.Get("menu.better_crafting.can_craft.cooking_tool_level", "@C{red}@M{" + toolId + "}", allowed, required);
-					e.Fail(s);
-				}
-			}
-		}
+        private void BetterCrafting_CheckCanCraft(ICheckCanCraftEvent e)
+        {
+            if (ModEntry.Config.AddCookingToolProgression && e.IsCooking)
+            {
+                int level = CookingTool.GetEffectiveGlobalLevel();
+                int allowed = CookingTool.NumIngredientsAllowed(level: level);
+                int required = e.Recipe.Ingredients?.Length ?? 0;
+                string toolId = CookingTool.ToolID(level: level);
+                if (allowed < required)
+                {
+                    string s = Strings.Get("menu.better_crafting.can_craft.cooking_tool_level", "@C{red}@M{" + toolId + "}", allowed, required);
+                    e.Fail(s);
+                }
+            }
+        }
 
-		private void BetterCrafting_ApplySeasoning(IApplySeasoningEvent e)
-		{
-			if (e.Item is StardewValley.Object o && o.Quality is StardewValley.Object.lowQuality)
-			{
-				foreach ((string itemId, IIngredient seasoning) in ModEntry.BetterCraftingSeasonings)
-				{
-					if (e.HasIngredients(seasoning) && ModEntry.Definitions.Seasonings.TryGetValue(itemId, out SeasoningData data))
-					{
-						o.Quality = data.Quality;
-						e.SetUsedLastMessage(Game1.content.LoadString(data.MessageStringKey, seasoning.DisplayName));
-						e.ApplySeasoning(seasoning);
-						return;
-					}
-				}
-			}
-		}
+        private void BetterCrafting_ApplySeasoning(IApplySeasoningEvent e)
+        {
+            if (e.Item is StardewValley.Object o && o.Quality is StardewValley.Object.lowQuality)
+            {
+                foreach ((string itemId, IIngredient seasoning) in ModEntry.BetterCraftingSeasonings)
+                {
+                    if (e.HasIngredients(seasoning) && ModEntry.Definitions.Seasonings.TryGetValue(itemId, out SeasoningData data))
+                    {
+                        o.Quality = data.Quality;
+                        e.SetUsedLastMessage(Game1.content.LoadString(data.MessageStringKey, seasoning.DisplayName));
+                        e.ApplySeasoning(seasoning);
+                        return;
+                    }
+                }
+            }
+        }
 
-		private void BetterCrafting_PostCraft(IPostCraftEvent e)
-		{
-			if (e.Recipe.CraftingRecipe is CraftingRecipe recipe && recipe.isCookingRecipe)
-			{
-				Item output = e.Item;
-				Utils.TryCookingSkillBehavioursOnCooked(
-					recipe: recipe,
-					item: ref output);
-				Utils.TryBurnFoodForBetterCrafting(
-					menu: e.Menu,
-					recipe: recipe,
-					input: ref output);
-				e.Item = output;
-			}
-		}
+        private void BetterCrafting_PostCraft(IPostCraftEvent e)
+        {
+            if (e.Recipe.CraftingRecipe is CraftingRecipe recipe && recipe.isCookingRecipe)
+            {
+                Item output = e.Item;
+                Utils.TryCookingSkillBehavioursOnCooked(
+                    recipe: recipe,
+                    item: ref output);
+                Utils.TryBurnFoodForBetterCrafting(
+                    menu: e.Menu,
+                    recipe: recipe,
+                    input: ref output);
+                e.Item = output;
+            }
+        }
 
-		private bool Init()
-		{
-			try
-			{
-				// Interfaces
-				if (!Interfaces.Init())
-				{
-					throw new Exception("Failed to load mod-provided APIs.");
-				}
+        private bool Init()
+        {
+            try
+            {
+                // Interfaces
+                if (!Interfaces.Init())
+                {
+                    throw new Exception("Failed to load mod-provided APIs.");
+                }
 
-				Interfaces.RegisterContentPatcherTokens();
+                Interfaces.RegisterContentPatcherTokens();
 
-				return true;
-			}
-			catch (Exception ex)
-			{
-				Log.E(ex.ToString());
-				Log.E($"{this.ModManifest.Name} failed to initialise. Mod may not be usable.");
-			}
-			return false;
-		}
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.E(ex.ToString());
+                Log.E($"{this.ModManifest.Name} failed to initialise. Mod may not be usable.");
+            }
+            return false;
+        }
 
-		private void InitLate()
-		{
-			try
-			{
-				// Interfaces (register)
-				Interfaces.Load();
+        private void InitLate()
+        {
+            try
+            {
+                // Interfaces (register)
+                Interfaces.Load();
 
-				// Game state queries
-				Queries.RegisterAll();
+                // Game state queries
+                Queries.RegisterAll();
 
-				// Harmony patches
-				HarmonyPatches.HarmonyPatches.Patch(id: this.ModManifest.UniqueID);
+                // Harmony patches
+                HarmonyPatches.HarmonyPatches.Patch(id: this.ModManifest.UniqueID);
 
-				// Game events
-				this.RegisterEvents();
+                // Game events
+                this.RegisterEvents();
 
-				// Assets and definitions
-				this.ReloadAssets();
+                // Assets and definitions
+                this.ReloadAssets();
 
-				// Console commands
-				this.AddConsoleCommands();
+                // Console commands
+                this.AddConsoleCommands();
 
-				// Interfaces (with content)
-				Interfaces.LoadOptionalMods();
+                // Interfaces (with content)
+                Interfaces.LoadOptionalMods();
 
-				// Cooking skill
-				ModEntry.CookingSkillApi = new CookingSkillAPI(this.Helper.Reflection);
-				SpaceCore.Skills.RegisterSkill(new CookingSkill());
-			}
-			catch (Exception e)
-			{
-				Log.E(e.ToString());
-				Log.E($"{this.ModManifest.Name} failed to load completely. Mod may not be usable.");
-			}
-		}
+                // Cooking skill
+                SpaceCore.Skills.RegisterSkill(new CookingSkill());
+            }
+            catch (Exception e)
+            {
+                Log.E(e.ToString());
+                Log.E($"{this.ModManifest.Name} failed to load completely. Mod may not be usable.");
+            }
+        }
 
-		public void ReloadAssets()
-		{
-			ModEntry.Definitions = Game1.content.Load
-				<Definitions>
-				(AssetManager.GameContentDefinitionsPath);
-			ModEntry.SpriteSheet = Game1.content.Load
-				<Texture2D>
-				(AssetManager.GameContentSpriteSheetPath);
-			CookbookAnimation.Reload(this.Helper);
-			this.States.Value.Regeneration.UpdateDefinitions();
-			Strings.Reload();
+        public void ReloadAssets()
+        {
+            ModEntry.Definitions = Game1.content.Load
+                <Definitions>
+                (AssetManager.GameContentDefinitionsPath);
+            ModEntry.SpriteSheet = Game1.content.Load
+                <Texture2D>
+                (AssetManager.GameContentSpriteSheetPath);
+            CookbookAnimation.Reload(this.Helper);
+            this.States.Value.Regeneration.UpdateDefinitions();
+            Strings.Reload();
 
-			// Order custom seasonings by descending quality, ensuring best seasonings are consumed first
-			ModEntry.Definitions.Seasonings = ModEntry.Definitions.Seasonings
-				.OrderByDescending(pair => pair.Value.Quality)
-				.ToDictionary(pair => pair.Key, pair => pair.Value);
+            // Order custom seasonings by descending quality, ensuring best seasonings are consumed first
+            ModEntry.Definitions.Seasonings = ModEntry.Definitions.Seasonings
+                .OrderByDescending(pair => pair.Value.Quality)
+                .ToDictionary(pair => pair.Key, pair => pair.Value);
 
-			if (ModEntry.CookingSkillApi?.GetSkill() is CookingSkill skill)
-			{
-				skill.ReloadAssets();
-			}
+            if (ModEntry.CookingSkillApi?.GetSkill() is CookingSkill skill)
+            {
+                skill.ReloadAssets();
+            }
 
-			if (Interfaces.BetterCraftingApi is IBetterCrafting betterCrafting)
-			{
-				ModEntry.BetterCraftingSeasonings = ModEntry.Definitions.Seasonings.ToDictionary(
-					pair => pair.Key,
-					pair => betterCrafting.CreateBaseIngredient(pair.Key, pair.Value.Quality));
-			}
-		}
+            if (Interfaces.BetterCraftingApi is IBetterCrafting betterCrafting)
+            {
+                ModEntry.BetterCraftingSeasonings = ModEntry.Definitions.Seasonings.ToDictionary(
+                    pair => pair.Key,
+                    pair => betterCrafting.CreateBaseIngredient(pair.Key, pair.Value.Quality));
+            }
+        }
 
-		private void PrintConfig()
-		{
-			try
-			{
-				Log.D($"{Environment.NewLine}== CONFIG SUMMARY =={Environment.NewLine}"
-					  + $"{Environment.NewLine}Cooking Menu:   {Config.AddCookingMenu}"
-					  + $"{Environment.NewLine}Cooking Skill:  {Config.AddCookingSkillAndRecipes}"
-					  + $"{Environment.NewLine}Cooking Tool:   {Config.AddCookingToolProgression}"
-					  + $"{Environment.NewLine}-------------"
-					  + $"{Environment.NewLine}Add Seasonings:       {Config.AddSeasonings}"
-					  + $"{Environment.NewLine}Town Kitchens:        {Config.CanUseTownKitchens}"
-					  + $"{Environment.NewLine}Food Heal Takes Time: {Config.FoodHealingTakesTime}"
-					  + $"{Environment.NewLine}Food Buffs Hidden:    {Config.FoodBuffsStartHidden}"
-					  + $"{Environment.NewLine}Food Can Burn:        {Config.FoodCanBurn}"
-					  + $"{Environment.NewLine}-------------"
-					  + $"{Environment.NewLine}Menu Animation:       {Config.PlayMenuAnimation}"
-					  + $"{Environment.NewLine}Cooking Animation:    {Config.PlayCookingAnimation}"
-					  + $"{Environment.NewLine}Show Healing Bar:     {Config.ShowFoodRegenBar}"
-					  + $"{Environment.NewLine}Remember Filter:      {Config.RememberSearchFilter}"
-					  + $"{Environment.NewLine}Default Filter:       {Config.DefaultSearchFilter}"
-					  + $"{Environment.NewLine}Default Sorter:       {Config.DefaultSearchSorter}"
-					  + $"{Environment.NewLine}-------------"
-					  + $"{Environment.NewLine}Debugging:      {Config.DebugMode}"
-					  + $"{Environment.NewLine}Resize Korean:  {Config.ResizeKoreanFonts}{Environment.NewLine}",
-					Config.DebugMode);
-			}
-			catch (Exception e)
-			{
-				Log.E($"Error in printing mod configuration.{Environment.NewLine}{e}");
-			}
-		}
+        private void PrintConfig()
+        {
+            try
+            {
+                Log.D($"{Environment.NewLine}== CONFIG SUMMARY =={Environment.NewLine}"
+                      + $"{Environment.NewLine}Cooking Menu:   {Config.AddCookingMenu}"
+                      + $"{Environment.NewLine}Cooking Skill:  {Config.AddCookingSkillAndRecipes}"
+                      + $"{Environment.NewLine}Cooking Tool:   {Config.AddCookingToolProgression}"
+                      + $"{Environment.NewLine}-------------"
+                      + $"{Environment.NewLine}Add Seasonings:       {Config.AddSeasonings}"
+                      + $"{Environment.NewLine}Town Kitchens:        {Config.CanUseTownKitchens}"
+                      + $"{Environment.NewLine}Food Heal Takes Time: {Config.FoodHealingTakesTime}"
+                      + $"{Environment.NewLine}Food Buffs Hidden:    {Config.FoodBuffsStartHidden}"
+                      + $"{Environment.NewLine}Food Can Burn:        {Config.FoodCanBurn}"
+                      + $"{Environment.NewLine}-------------"
+                      + $"{Environment.NewLine}Menu Animation:       {Config.PlayMenuAnimation}"
+                      + $"{Environment.NewLine}Cooking Animation:    {Config.PlayCookingAnimation}"
+                      + $"{Environment.NewLine}Show Healing Bar:     {Config.ShowFoodRegenBar}"
+                      + $"{Environment.NewLine}Remember Filter:      {Config.RememberSearchFilter}"
+                      + $"{Environment.NewLine}Default Filter:       {Config.DefaultSearchFilter}"
+                      + $"{Environment.NewLine}Default Sorter:       {Config.DefaultSearchSorter}"
+                      + $"{Environment.NewLine}-------------"
+                      + $"{Environment.NewLine}Debugging:      {Config.DebugMode}"
+                      + $"{Environment.NewLine}Resize Korean:  {Config.ResizeKoreanFonts}{Environment.NewLine}",
+                    Config.DebugMode);
+            }
+            catch (Exception e)
+            {
+                Log.E($"Error in printing mod configuration.{Environment.NewLine}{e}");
+            }
+        }
 
-		private void PrintModData()
-		{
-			try
-			{
-				Log.D($"{Environment.NewLine}== LOCAL DATA =={Environment.NewLine}"
-					+ $"{Environment.NewLine}RecipeGridView:   {this.States.Value.IsUsingRecipeGridView}"
-					+ $"{Environment.NewLine}CookingToolLevel: {this.States.Value.CookingToolLevel}"
-					+ $"{Environment.NewLine}FoodsEaten:       {string.Join(" ", this.States.Value.FoodsEaten.Select(s => $"({s})"))}"
-					+ $"{Environment.NewLine}FavouriteRecipes: {string.Join(" ", this.States.Value.FavouriteRecipes.Select(s => $"({s})"))}"
-					+ $"{Environment.NewLine}CookbookUnlocked: {Utils.HasCookbook(Game1.player)}"
-					+ $"{Environment.NewLine}Language:         {LocalizedContentManager.CurrentLanguageCode.ToString().ToUpper()}{Environment.NewLine}",
-					ModEntry.Config.DebugMode);
-			}
-			catch (Exception e)
-			{
-				Log.E($"Error in printing mod save data.{Environment.NewLine}{e}");
-			}
-		}
+        private void PrintModData()
+        {
+            try
+            {
+                Log.D($"{Environment.NewLine}== LOCAL DATA =={Environment.NewLine}"
+                    + $"{Environment.NewLine}RecipeGridView:   {this.States.Value.IsUsingRecipeGridView}"
+                    + $"{Environment.NewLine}CookingToolLevel: {this.States.Value.CookingToolLevel}"
+                    + $"{Environment.NewLine}FoodsEaten:       {string.Join(" ", this.States.Value.FoodsEaten.Select(s => $"({s})"))}"
+                    + $"{Environment.NewLine}FavouriteRecipes: {string.Join(" ", this.States.Value.FavouriteRecipes.Select(s => $"({s})"))}"
+                    + $"{Environment.NewLine}CookbookUnlocked: {Utils.HasCookbook(Game1.player)}"
+                    + $"{Environment.NewLine}Language:         {LocalizedContentManager.CurrentLanguageCode.ToString().ToUpper()}{Environment.NewLine}",
+                    ModEntry.Config.DebugMode);
+            }
+            catch (Exception e)
+            {
+                Log.E($"Error in printing mod save data.{Environment.NewLine}{e}");
+            }
+        }
 
-		private void PrintCookingSkill()
-		{
-			if (!ModEntry.Config.AddCookingSkillAndRecipes)
-			{
-				Log.D("Cooking skill is disabled in mod config.",
-					ModEntry.Config.DebugMode);
-			}
-			else if (ModEntry.CookingSkillApi?.GetSkill() is null)
-			{
-				Log.D("Cooking skill is enabled, but skill is not loaded.",
-					ModEntry.Config.DebugMode);
-			}
-			else
-			{
-				try
-				{
-					int level = ModEntry.CookingSkillApi.GetLevel();
-					int current = ModEntry.CookingSkillApi.GetTotalCurrentExperience();
-					int total = ModEntry.CookingSkillApi.GetTotalExperienceRequiredForLevel(level + 1);
-					int remaining = ModEntry.CookingSkillApi.GetExperienceRemainingUntilLevel(level + 1);
-					int required = ModEntry.CookingSkillApi.GetExperienceRequiredForLevel(level + 1);
-					string professions = string.Join(Environment.NewLine,
-						ModEntry.CookingSkillApi.GetCurrentProfessions().Select(pair => $"\t{pair.Key}: {pair.Value}"));
-					Log.D($"{Environment.NewLine}== COOKING SKILL =={Environment.NewLine}"
-						+ $"{Environment.NewLine}ID: {CookingSkillApi.GetSkill().GetName()}"
-						+ $"{Environment.NewLine}Cooking level: {level}"
-						+ $"{Environment.NewLine}Experience until next level: ({required - remaining}/{required})"
-						+ $"{Environment.NewLine}Total experience: ({current}/{total})"
-						+ $"{Environment.NewLine}Current professions:{Environment.NewLine}{professions}{Environment.NewLine}",
-						ModEntry.Config.DebugMode);
-				}
-				catch (Exception e)
-				{
-					Log.E($"Error in printing custom skill data.{Environment.NewLine}{e}");
-				}
-			}
-		}
-	}
+        private void PrintCookingSkill()
+        {
+            if (!ModEntry.Config.AddCookingSkillAndRecipes)
+            {
+                Log.D("Cooking skill is disabled in mod config.",
+                    ModEntry.Config.DebugMode);
+            }
+            else if (ModEntry.CookingSkillApi?.GetSkill() is null)
+            {
+                Log.D("Cooking skill is enabled, but skill is not loaded.",
+                    ModEntry.Config.DebugMode);
+            }
+            else
+            {
+                try
+                {
+                    int level = ModEntry.CookingSkillApi.GetLevel();
+                    int current = ModEntry.CookingSkillApi.GetTotalCurrentExperience();
+                    int total = ModEntry.CookingSkillApi.GetTotalExperienceRequiredForLevel(level + 1);
+                    int remaining = ModEntry.CookingSkillApi.GetExperienceRemainingUntilLevel(level + 1);
+                    int required = ModEntry.CookingSkillApi.GetExperienceRequiredForLevel(level + 1);
+                    string professions = string.Join(Environment.NewLine,
+                        ModEntry.CookingSkillApi.GetCurrentProfessions().Select(pair => $"\t{pair.Key}: {pair.Value}"));
+                    Log.D($"{Environment.NewLine}== COOKING SKILL =={Environment.NewLine}"
+                        + $"{Environment.NewLine}ID: {CookingSkillApi.GetSkill().GetName()}"
+                        + $"{Environment.NewLine}Cooking level: {level}"
+                        + $"{Environment.NewLine}Experience until next level: ({required - remaining}/{required})"
+                        + $"{Environment.NewLine}Total experience: ({current}/{total})"
+                        + $"{Environment.NewLine}Current professions:{Environment.NewLine}{professions}{Environment.NewLine}",
+                        ModEntry.Config.DebugMode);
+                }
+                catch (Exception e)
+                {
+                    Log.E($"Error in printing custom skill data.{Environment.NewLine}{e}");
+                }
+            }
+        }
+    }
 }

--- a/LoveOfCooking/Menu/CookingManager.cs
+++ b/LoveOfCooking/Menu/CookingManager.cs
@@ -9,7 +9,7 @@ using StardewValley.Quests;
 
 namespace LoveOfCooking.Menu
 {
-	public class CookingManager
+    public class CookingManager
     {
         private readonly CookingMenu _cookingMenu;
         private const int DefaultIngredientsSlots = 6;
@@ -24,8 +24,8 @@ namespace LoveOfCooking.Menu
             get => this._maxIngredients;
             set
             {
-				this._maxIngredients = value;
-				this.CurrentIngredients = new List<Ingredient?>(this._maxIngredients);
+                this._maxIngredients = value;
+                this.CurrentIngredients = new List<Ingredient?>(this._maxIngredients);
             }
         }
         private List<Ingredient?> _currentIngredients;
@@ -34,12 +34,12 @@ namespace LoveOfCooking.Menu
             get => this._currentIngredients;
             private set
             {
-				this._currentIngredients = value;
+                this._currentIngredients = value;
                 for (int i = 0; i < Math.Max(DefaultIngredientsSlots, this.MaxIngredients); ++i)
                 {
-					this._currentIngredients.Add(null);
+                    this._currentIngredients.Add(null);
                 }
-				this._cookingMenu.CreateIngredientSlotButtons(
+                this._cookingMenu.CreateIngredientSlotButtons(
                     buttonsToDisplay: this._currentIngredients.Count,
                     usableButtons: this.MaxIngredients);
             }
@@ -47,10 +47,11 @@ namespace LoveOfCooking.Menu
         private bool _isUsingSeasonings;
         internal bool IsUsingSeasonings
         {
-			get => this._isUsingSeasonings;
-            set {
-				this._isUsingSeasonings = value;
-			}
+            get => this._isUsingSeasonings;
+            set
+            {
+                this._isUsingSeasonings = value;
+            }
         }
 
         internal struct Ingredient
@@ -61,9 +62,9 @@ namespace LoveOfCooking.Menu
 
             public Ingredient(int whichInventory, int whichItem, string itemId)
             {
-				this.WhichInventory = whichInventory;
-				this.WhichItem = whichItem;
-				this.ItemId = itemId;
+                this.WhichInventory = whichInventory;
+                this.WhichItem = whichItem;
+                this.ItemId = itemId;
             }
 
             public static bool operator ==(Ingredient obj1, object obj2)
@@ -86,7 +87,7 @@ namespace LoveOfCooking.Menu
 
         public CookingManager(CookingMenu menu)
         {
-			this._cookingMenu = menu;
+            this._cookingMenu = menu;
         }
 
         /// <summary>
@@ -95,13 +96,13 @@ namespace LoveOfCooking.Menu
         /// </summary>
         public static float GetBurnChance(CraftingRecipe recipe)
         {
-			float minimumChance = 0f;
+            float minimumChance = 0f;
             if (!ModEntry.Config.FoodCanBurn)
                 return minimumChance;
 
             int cookingLevel = ModEntry.CookingSkillApi.GetLevel();
-			float baseRate = ModEntry.Definitions.BurnChanceBase;
-			float addedRate = ModEntry.Definitions.BurnChancePerIngredient;
+            float baseRate = ModEntry.Definitions.BurnChanceBase;
+            float addedRate = ModEntry.Definitions.BurnChancePerIngredient;
             float chance = Math.Max(minimumChance, baseRate + addedRate * recipe.getNumberOfIngredients()
                 - cookingLevel * ModEntry.Definitions.CookingSkillValues.BurnChanceModifier * ModEntry.Definitions.CookingSkillValues.BurnChanceReduction
                 - CookingTool.GetEffectiveGlobalLevel() / 2f * ModEntry.Definitions.CookingSkillValues.BurnChanceModifier * ModEntry.Definitions.CookingSkillValues.BurnChanceReduction);
@@ -150,9 +151,9 @@ namespace LoveOfCooking.Menu
         /// <param name="limit">Maximum number of matching ingredients to return.</param>
         internal static List<Ingredient> GetMatchingIngredients(string id, List<IList<Item>> sourceItems, int required, int limit = DefaultIngredientsSlots)
         {
-			List<Ingredient> foundIngredients = [];
-			int ingredientsFulfilled = 0;
-			int ingredientsRequired = required;
+            List<Ingredient> foundIngredients = [];
+            int ingredientsFulfilled = 0;
+            int ingredientsRequired = required;
             for (int i = 0; i < sourceItems.Count; ++i)
             {
                 for (int j = 0; j < sourceItems[i].Count && ingredientsFulfilled < limit; ++j)
@@ -161,8 +162,8 @@ namespace LoveOfCooking.Menu
                         && (IsMatchingIngredient(id: id, item: sourceItems[i][j])
                             || CraftingRecipe.isThereSpecialIngredientRule((StardewValley.Object)sourceItems[i][j], id)))
                     {
-						// Mark ingredient as matched
-						Ingredient ingredient = new(whichInventory: i, whichItem: j, itemId: sourceItems[i][j].ItemId);
+                        // Mark ingredient as matched
+                        Ingredient ingredient = new(whichInventory: i, whichItem: j, itemId: sourceItems[i][j].ItemId);
                         foundIngredients.Add(ingredient);
 
                         // Count up number of fulfilled ingredients
@@ -181,9 +182,9 @@ namespace LoveOfCooking.Menu
 
         private int GetAmountCraftable(CraftingRecipe recipe, List<IList<Item>> sourceItems, List<Ingredient> ingredients)
         {
-			List<IList<Item>> ingredientsItems =
-			[
-				ingredients.Select(i => this.GetItemForIngredient(ingredient: i, sourceItems: sourceItems)).ToList()
+            List<IList<Item>> ingredientsItems =
+            [
+                ingredients.Select(i => this.GetItemForIngredient(ingredient: i, sourceItems: sourceItems)).ToList()
             ];
             return this.GetAmountCraftable(recipe: recipe, sourceItems: ingredientsItems, limitToCurrentIngredients: true);
         }
@@ -248,7 +249,7 @@ namespace LoveOfCooking.Menu
         /// </returns>
         internal Dictionary<int, int> ChooseIngredientsForCrafting(CraftingRecipe recipe, List<IList<Item>> sourceItems)
         {
-			Dictionary<int, int> ingredientsToConsume = [];
+            Dictionary<int, int> ingredientsToConsume = [];
             foreach (KeyValuePair<string, int> itemAndQuantity in recipe.recipeList)
             {
                 int remainingRequired = itemAndQuantity.Value;
@@ -260,7 +261,7 @@ namespace LoveOfCooking.Menu
                     Item item = this.GetItemForIngredient(index: i, sourceItems: sourceItems);
                     if (item is null)
                     {
-						this.CurrentIngredients[i] = null; // No items were found for this ingredient, prevent it being checked later
+                        this.CurrentIngredients[i] = null; // No items were found for this ingredient, prevent it being checked later
                         continue;
                     }
                     if (IsMatchingIngredient(id: itemAndQuantity.Key, item: item))
@@ -281,37 +282,45 @@ namespace LoveOfCooking.Menu
             return ingredientsToConsume;
         }
 
-        internal List<StardewValley.Object> CraftItemAndConsumeIngredients(CraftingRecipe recipe, List<IList<Item>> sourceItems, int quantity, out int burntQuantity)
+        internal IList<StardewValley.Object> CraftItemAndConsumeIngredients(CraftingRecipe recipe, List<IList<Item>> sourceItems, int quantity, out int burntQuantity)
         {
             {
                 string msg1 = $"Cooking {recipe.name} x{quantity}";
-				string msg2 = recipe.recipeList.Aggregate("Requires: ", (str, pair) => $"{str} ({pair.Key} x{pair.Value})");
-				string msg3 = sourceItems.Aggregate("Sources: ", (str, list) => $"{str} ({sourceItems.IndexOf(list)} x{list.Count})");
-				string msg4 = this.CurrentIngredients.Aggregate("Current: ", (str, i) => $"{str} [{(i.HasValue ? i.Value.WhichInventory + ", " + i.Value.WhichItem : "null")}]");
+                string msg2 = recipe.recipeList.Aggregate("Requires: ", (str, pair) => $"{str} ({pair.Key} x{pair.Value})");
+                string msg3 = sourceItems.Aggregate("Sources: ", (str, list) => $"{str} ({sourceItems.IndexOf(list)} x{list.Count})");
+                string msg4 = this.CurrentIngredients.Aggregate("Current: ", (str, i) => $"{str} [{(i.HasValue ? i.Value.WhichInventory + ", " + i.Value.WhichItem : "null")}]");
                 Log.D(string.Join(Environment.NewLine, [msg1, msg2, msg3, msg4]),
                     ModEntry.Config.DebugMode);
             }
 
-            // Identify items to be consumed from inventory to fulfil ingredients requirements
+            // Identify items to be consumed from inventory to fulfill ingredients requirements
             Dictionary<int, int> ingredientsToConsume = this.ChooseIngredientsForCrafting(recipe: recipe, sourceItems: sourceItems);
-			// Set up dictionary for populating with quantities of different quality levels
-			Dictionary<int, int> qualityStacks = new() { { 0, 0 }, { 1, 0 }, { 2, 0 }, { 4, 0 } };
+            // Set up dictionary for populating with quantities of different quality levels
+            Dictionary<int, int> qualityStacks = new() { { 0, 0 }, { 1, 0 }, { 2, 0 }, { 4, 0 } };
             int numPerCraft = recipe.numberProducedPerCraft;
 
             {
-				string msg1 = "Indices: " + (ingredientsToConsume is not null
+                string msg1 = "Indices: " + (ingredientsToConsume is not null
                     ? ingredientsToConsume.Aggregate("", (str, pair) => $"{str} ({pair.Key} {pair.Value})")
                     : "null");
                 Log.D($"{msg1}",
                     ModEntry.Config.DebugMode);
             }
 
+            // A collection of (cloned) ingredient lists for use with the API. Each list corresponds to the ingredients used for one craft.
+            IList<IList<Item>> usedIngredientsLists = new List<IList<Item>>();
             for (int i = 0; i < quantity && ingredientsToConsume is not null; ++i)
             {
+                var usedIngredients = new List<Item>();
                 // Consume ingredients from source lists
                 foreach (KeyValuePair<int, int> indexAndQuantity in ingredientsToConsume.ToList())
                 {
                     Ingredient ingredient = this.CurrentIngredients[indexAndQuantity.Key].Value;
+
+                    var clonedItem = sourceItems[ingredient.WhichInventory][ingredient.WhichItem].getOne();
+                    clonedItem.Stack = indexAndQuantity.Value;
+                    usedIngredients.Add(clonedItem);
+
                     if ((sourceItems[ingredient.WhichInventory][ingredient.WhichItem].Stack -= indexAndQuantity.Value) < 1)
                     {
                         if (ingredient.WhichInventory == InventoryManager.BackpackInventoryId)
@@ -330,7 +339,7 @@ namespace LoveOfCooking.Menu
                                     && this.CurrentIngredients[j].Value.WhichInventory == ingredient.WhichInventory
                                     && this.CurrentIngredients[j].Value.WhichItem > ingredient.WhichItem)
                                 {
-									this.CurrentIngredients[j] = new Ingredient(
+                                    this.CurrentIngredients[j] = new Ingredient(
                                         whichInventory: this.CurrentIngredients[j].Value.WhichInventory,
                                         whichItem: this.CurrentIngredients[j].Value.WhichItem - 1,
                                         itemId: this.CurrentIngredients[j].Value.ItemId);
@@ -339,6 +348,8 @@ namespace LoveOfCooking.Menu
                         }
                     }
                 }
+                // Record the used ingredients for this one craft
+                usedIngredientsLists.Add(usedIngredients);
 
                 // Add to stack
                 qualityStacks[0] += numPerCraft;
@@ -347,48 +358,57 @@ namespace LoveOfCooking.Menu
                 if (Utils.TryApplyCookingQuantityBonus())
                 {
                     qualityStacks[0] += numPerCraft;
+                    // Add another list of ingredients since we're crafting twice
+                    usedIngredientsLists.Add(usedIngredients.Select(item =>
+                    {
+                        var newItem = item.getOne();
+                        newItem.Stack = item.Stack;
+                        return newItem;
+                    }).ToList());
                 }
 
                 // Choose new ingredients until none are found
                 ingredientsToConsume = this.ChooseIngredientsForCrafting(recipe: recipe, sourceItems: sourceItems);
+
             }
 
-			// Apply seasoning quality bonuses to the stack choices
-			if (this.IsUsingSeasonings) {
-			    // Consume seasoning items to improve the recipe output item qualities, rebalancing the stack numbers per quality item
-				// Stop iterating when we've run out of standard quality ingredients or no more seasonings can be found
-				List<Item> items = sourceItems.SelectMany(list => list).ToList();
-				List<IInventory> inventories = this._cookingMenu.InventoryManager.Inventories.Select(pair => pair.Inventory).ToList();
-				List<KeyValuePair<string, int>> seasoning = [];
-				int quality = 0;
-				do
-				{
+            // Apply seasoning quality bonuses to the stack choices
+            if (this.IsUsingSeasonings)
+            {
+                // Consume seasoning items to improve the recipe output item qualities, rebalancing the stack numbers per quality item
+                // Stop iterating when we've run out of standard quality ingredients or no more seasonings can be found
+                List<Item> items = sourceItems.SelectMany(list => list).ToList();
+                List<IInventory> inventories = this._cookingMenu.InventoryManager.Inventories.Select(pair => pair.Inventory).ToList();
+                List<KeyValuePair<string, int>> seasoning = [];
+                int quality = 0;
+                do
+                {
                     seasoning.Clear();
-					quality = Utils.GetOneSeasoningFromInventory(expandedInventory: items, seasoning: seasoning);
-					if (quality > 0)
-					{
-						// Reduce the base quality stack
-						qualityStacks[0] -= numPerCraft;
+                    quality = Utils.GetOneSeasoningFromInventory(expandedInventory: items, seasoning: seasoning);
+                    if (quality > 0)
+                    {
+                        // Reduce the base quality stack
+                        qualityStacks[0] -= numPerCraft;
 
-						// Increase higher quality stacks
-						qualityStacks[quality] += numPerCraft;
+                        // Increase higher quality stacks
+                        qualityStacks[quality] += numPerCraft;
 
-						// Remove consumed seasonings
-						if (seasoning.Any())
-						{
-							CraftingRecipe.ConsumeAdditionalIngredients(seasoning, inventories);
-							if (!CraftingRecipe.DoesFarmerHaveAdditionalIngredientsInInventory(seasoning, items))
-							{
+                        // Remove consumed seasonings
+                        if (seasoning.Any())
+                        {
+                            CraftingRecipe.ConsumeAdditionalIngredients(seasoning, inventories);
+                            if (!CraftingRecipe.DoesFarmerHaveAdditionalIngredientsInInventory(seasoning, items))
+                            {
                                 Utils.SendSeasoningUsedMessage(seasoning: seasoning);
-							}
-						}
-					}
-				}
-				while (qualityStacks[0] > 0 && quality > 0);
-			}
+                            }
+                        }
+                    }
+                }
+                while (qualityStacks[0] > 0 && quality > 0);
+            }
 
-			// Apply burn chance to destroy cooked food at random
-			burntQuantity = 0;
+            // Apply burn chance to destroy cooked food at random
+            burntQuantity = 0;
             List<int> qualities = qualityStacks.Keys.ToList();
             foreach (int quality in qualities)
             {
@@ -402,22 +422,25 @@ namespace LoveOfCooking.Menu
                 }
             }
 
-			// Create item list from quality stacks
-			List<StardewValley.Object> itemsCooked = [];
+            // Create item list from quality stacks
+            IList<StardewValley.Object> itemsCooked = [];
             foreach (KeyValuePair<int, int> pair in qualityStacks.Where(pair => pair.Value > 0))
             {
-				StardewValley.Object item = recipe.createItem() as StardewValley.Object;
+                StardewValley.Object item = recipe.createItem() as StardewValley.Object;
                 item.Quality = pair.Key;
                 item.Stack = pair.Value;
                 itemsCooked.Add(item);
             }
-            return itemsCooked;
+            // Run the cook event handlers, replacing the items with the modified one if necessary
+            PostCookEvent ev = new(recipe, Game1.player, itemsCooked, usedIngredientsLists);
+            (ModEntry.CookingSkillApi as CookingSkillAPI).FirePostCookEvents(ev);
+            return ev.CookedItems ?? itemsCooked;
         }
 
         internal int CookRecipe(CraftingRecipe recipe, List<IList<Item>> sourceItems, int quantity, out int burntQuantity)
         {
             // Craft items to be cooked from recipe
-            List<StardewValley.Object> itemsCooked = this.CraftItemAndConsumeIngredients(recipe, sourceItems, quantity, out burntQuantity);
+            IList<StardewValley.Object> itemsCooked = this.CraftItemAndConsumeIngredients(recipe, sourceItems, quantity, out burntQuantity);
             int quantityCooked = Math.Max(0, itemsCooked.Sum(item => item.Stack) / recipe.numberProducedPerCraft - burntQuantity);
             Item item = recipe.createItem();
 
@@ -436,12 +459,12 @@ namespace LoveOfCooking.Menu
                 for (int i = 0; i < quantityCooked; ++i)
                 {
                     Game1.player.cookedRecipe(item.ItemId);
-					Game1.player.NotifyQuests((Quest quest) => quest.OnRecipeCrafted(recipe: recipe, item: item));
-				}
+                    Game1.player.NotifyQuests((Quest quest) => quest.OnRecipeCrafted(recipe: recipe, item: item));
+                }
 
                 // Update game stats
                 Game1.stats.ItemsCooked += (uint)quantityCooked;
-				Game1.stats.checkForCookingAchievements();
+                Game1.stats.checkForCookingAchievements();
             }
 
             // Add cooked items to inventory if possible
@@ -450,10 +473,10 @@ namespace LoveOfCooking.Menu
                 Utils.AddOrDropItem(cookedItem);
             }
 
-			// Add burnt items
+            // Add burnt items
             for (int i = 0; i < burntQuantity; ++i)
-			{
-				Utils.AddOrDropItem(Utils.CreateBurntFood());
+            {
+                Utils.AddOrDropItem(Utils.CreateBurntFood());
             }
 
             return quantityCooked;
@@ -461,7 +484,7 @@ namespace LoveOfCooking.Menu
 
         internal bool AddToIngredients(int whichInventory, int whichItem, string itemId)
         {
-			Ingredient ingredient = new(whichInventory: whichInventory, whichItem: whichItem, itemId: itemId);
+            Ingredient ingredient = new(whichInventory: whichInventory, whichItem: whichItem, itemId: itemId);
             return this.AddToIngredients(ingredient: ingredient);
         }
 
@@ -469,7 +492,7 @@ namespace LoveOfCooking.Menu
         {
             if (this.FirstEmptySlot < 0 || this.FirstEmptySlot >= this.MaxIngredients)
                 return false;
-			this.CurrentIngredients[this.FirstEmptySlot] = ingredient;
+            this.CurrentIngredients[this.FirstEmptySlot] = ingredient;
             return true;
         }
 
@@ -478,7 +501,7 @@ namespace LoveOfCooking.Menu
             int index = this.CurrentIngredients.FindIndex(i => i.HasValue && i.Value.WhichInventory == inventoryId && i.Value.WhichItem == itemIndex);
             if (index < 0)
                 return false;
-			this.CurrentIngredients[index] = null;
+            this.CurrentIngredients[index] = null;
             return true;
         }
 
@@ -486,7 +509,7 @@ namespace LoveOfCooking.Menu
         {
             if (ingredientsIndex < 0 || ingredientsIndex >= this.CurrentIngredients.Count || this.CurrentIngredients[ingredientsIndex] is null)
                 return false;
-			this.CurrentIngredients[ingredientsIndex] = null;
+            this.CurrentIngredients[ingredientsIndex] = null;
             return true;
         }
 
@@ -517,9 +540,9 @@ namespace LoveOfCooking.Menu
                     .ToList())
                 .ToList();
 
-			// Add items from each list of matching ingredients in turn
-			// This should create a mixed list where each required item has an ingredient represented
-			List<Ingredient> ingredientsToUse = [];
+            // Add items from each list of matching ingredients in turn
+            // This should create a mixed list where each required item has an ingredient represented
+            List<Ingredient> ingredientsToUse = [];
             int maxItems = matchingItemIndexes.Max(list => list.Count);
             int maxLists = matchingItemIndexes.Count;
             for (int whichItem = 0; whichItem < maxItems; ++whichItem)
@@ -530,7 +553,7 @@ namespace LoveOfCooking.Menu
             // Fill slots with select ingredients
             foreach (Ingredient ingredient in ingredientsToUse.Take(this.MaxIngredients))
             {
-				this.AddToIngredients(ingredient);
+                this.AddToIngredients(ingredient);
             }
         }
 
@@ -538,7 +561,7 @@ namespace LoveOfCooking.Menu
         {
             for (int i = 0; i < this.CurrentIngredients.Count; ++i)
             {
-				this.CurrentIngredients[i] = null;
+                this.CurrentIngredients[i] = null;
             }
         }
 

--- a/LoveOfCooking/Objects/CookingSkillAPI.cs
+++ b/LoveOfCooking/Objects/CookingSkillAPI.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using SpaceCore;
@@ -7,172 +8,182 @@ using StardewValley;
 
 namespace LoveOfCooking.Objects
 {
-	public interface ICookingSkillAPI
-	{
-		public enum Profession // DO NOT EDIT
-		{
-			ImprovedSeasoning,
-			Restoration,
-			GiftBoost,
-			SalePrice,
-			ExtraPortion,
-			BuffDuration
-		}
+    public interface ICookingSkillAPI
+    {
+        public enum Profession // DO NOT EDIT
+        {
+            ImprovedSeasoning,
+            Restoration,
+            GiftBoost,
+            SalePrice,
+            ExtraPortion,
+            BuffDuration
+        }
 
-		bool IsEnabled();
-		CookingSkill GetSkill();
-		int GetLevel();
-		int GetMaximumLevel();
-		IReadOnlyDictionary<ICookingSkillAPI.Profession, bool> GetCurrentProfessions(long playerID = -1L);
-		bool HasProfession(ICookingSkillAPI.Profession profession, long playerID = -1L);
-		bool AddExperienceDirectly(int experience);
-		void AddCookingBuffToItem(string name, int value);
-		int GetTotalCurrentExperience();
-		int GetExperienceRequiredForLevel(int level);
-		int GetTotalExperienceRequiredForLevel(int level);
-		int GetExperienceRemainingUntilLevel(int level);
-		IList<string> GetAllLoveOfCookingRecipes();
-		IReadOnlyDictionary<int, IList<string>> GetAllLevelUpRecipes();
+        bool IsEnabled();
+        CookingSkill GetSkill();
+        int GetLevel();
+        int GetMaximumLevel();
+        IReadOnlyDictionary<ICookingSkillAPI.Profession, bool> GetCurrentProfessions(long playerID = -1L);
+        bool HasProfession(ICookingSkillAPI.Profession profession, long playerID = -1L);
+        bool AddExperienceDirectly(int experience);
+        void AddCookingBuffToItem(string name, int value);
+        int GetTotalCurrentExperience();
+        int GetExperienceRequiredForLevel(int level);
+        int GetTotalExperienceRequiredForLevel(int level);
+        int GetExperienceRemainingUntilLevel(int level);
+        IList<string> GetAllLoveOfCookingRecipes();
+        IReadOnlyDictionary<int, IList<string>> GetAllLevelUpRecipes();
         IReadOnlyList<string> GetCookingRecipesForLevel(int level);
-		int CalculateExperienceGainedFromCookingItem(Item item, int numIngredients, int numCooked, bool applyExperience);
-		bool RollForExtraPortion();
-	}
+        int CalculateExperienceGainedFromCookingItem(Item item, int numIngredients, int numCooked, bool applyExperience);
+        bool RollForExtraPortion();
 
-	public class CookingSkillAPI : ICookingSkillAPI
-	{
-		private readonly IReflectionHelper Reflection;
+        public event Action<IPostCookEvent>? PostCook;
+    }
 
-		public CookingSkillAPI(IReflectionHelper reflection)
-		{
-			this.Reflection = reflection;
-		}
+    public interface IPostCookEvent
+    {
+        CraftingRecipe Recipe { get; }
+        Farmer Player { get; }
+        IList<StardewValley.Object> CookedItems { get; set; }
+        IList<IList<Item>> ConsumedItems { get; }
+    }
 
-		/// <returns>Whether the Cooking skill is enabled in the mod config.</returns>
-		public bool IsEnabled()
-		{
-			return ModEntry.Config.AddCookingSkillAndRecipes;
-		}
+    public class CookingSkillAPI : ICookingSkillAPI
+    {
+        private readonly IReflectionHelper Reflection;
 
-		/// <returns>Instance of the Cooking skill.</returns>
-		public CookingSkill GetSkill()
-		{
-			return SpaceCore.Skills.GetSkill(CookingSkill.InternalName) as CookingSkill;
-		}
+        public CookingSkillAPI(IReflectionHelper reflection)
+        {
+            this.Reflection = reflection;
+        }
 
-		/// <returns>Current base skill level.</returns>
-		public int GetLevel()
-		{
-			return SpaceCore.Skills.GetSkillLevel(Game1.player, CookingSkill.InternalName);
-		}
+        /// <returns>Whether the Cooking skill is enabled in the mod config.</returns>
+        public bool IsEnabled()
+        {
+            return ModEntry.Config.AddCookingSkillAndRecipes;
+        }
 
-		/// <returns>Maximum possible skill level.</returns>
-		public int GetMaximumLevel()
-		{
-			return this.GetSkill().ExperienceCurve.Length;
-		}
+        /// <returns>Instance of the Cooking skill.</returns>
+        public CookingSkill GetSkill()
+        {
+            return SpaceCore.Skills.GetSkill(CookingSkill.InternalName) as CookingSkill;
+        }
 
-		/// <returns>A dictionary of all possible Cooking professions and whether each is active.</returns>
-		public IReadOnlyDictionary<ICookingSkillAPI.Profession, bool> GetCurrentProfessions(long playerID = -1L)
-		{
-			var dict = new Dictionary<ICookingSkillAPI.Profession, bool>();
-			int count = Enum.GetNames(typeof(ICookingSkillAPI.Profession)).Length;
-			for (int i = 0; i < count; ++i)
-			{
-				var profession = (ICookingSkillAPI.Profession)i;
-				dict.Add(profession, this.HasProfession(profession: profession, playerID: playerID));
-			}
-			return dict;
-		}
+        /// <returns>Current base skill level.</returns>
+        public int GetLevel()
+        {
+            return SpaceCore.Skills.GetSkillLevel(Game1.player, CookingSkill.InternalName);
+        }
 
-		/// <returns>Whether the player has unlocked and chosen the given profession.</returns>
-		public bool HasProfession(ICookingSkillAPI.Profession profession, long playerID = -1L)
-		{
-			Farmer player = Game1.GetPlayer(playerID, onlyOnline: false) ?? Game1.MasterPlayer;
-			return (player ?? Game1.player).HasCustomProfession(this.GetSkill().Professions[(int)profession]);
-		}
+        /// <returns>Maximum possible skill level.</returns>
+        public int GetMaximumLevel()
+        {
+            return this.GetSkill().ExperienceCurve.Length;
+        }
 
-		/// <summary>
-		/// Not yet implemented
-		/// </summary>
-		/// <param name="name">Name of the item to receive the buff.</param>
-		/// <param name="value">Added skill level amount, will act as a debuff if negative.</param>
-		public void AddCookingBuffToItem(string name, int value)
-		{
-			if (value == 0)
-				return;
+        /// <returns>A dictionary of all possible Cooking professions and whether each is active.</returns>
+        public IReadOnlyDictionary<ICookingSkillAPI.Profession, bool> GetCurrentProfessions(long playerID = -1L)
+        {
+            var dict = new Dictionary<ICookingSkillAPI.Profession, bool>();
+            int count = Enum.GetNames(typeof(ICookingSkillAPI.Profession)).Length;
+            for (int i = 0; i < count; ++i)
+            {
+                var profession = (ICookingSkillAPI.Profession)i;
+                dict.Add(profession, this.HasProfession(profession: profession, playerID: playerID));
+            }
+            return dict;
+        }
 
-			throw new NotImplementedException();
-		}
+        /// <returns>Whether the player has unlocked and chosen the given profession.</returns>
+        public bool HasProfession(ICookingSkillAPI.Profession profession, long playerID = -1L)
+        {
+            Farmer player = Game1.GetPlayer(playerID, onlyOnline: false) ?? Game1.MasterPlayer;
+            return (player ?? Game1.player).HasCustomProfession(this.GetSkill().Professions[(int)profession]);
+        }
 
-		/// <summary>
-		/// Add experience to the skill.
-		/// Experience gains from cooking may be applied via CalculateExperienceGainedFromCookingItem. This method should not be used where CalculateExperience would be more appropriate.
-		/// </summary>
-		/// <returns>Whether the player gained a level from added experience.</returns>
-		public bool AddExperienceDirectly(int experience)
-		{
-			Events.InvokeOnCookingExperienceGained(experienceGained: experience);
+        /// <summary>
+        /// Not yet implemented
+        /// </summary>
+        /// <param name="name">Name of the item to receive the buff.</param>
+        /// <param name="value">Added skill level amount, will act as a debuff if negative.</param>
+        public void AddCookingBuffToItem(string name, int value)
+        {
+            if (value == 0)
+                return;
 
-			int level = this.GetLevel();
-			SpaceCore.Skills.AddExperience(Game1.player, CookingSkill.InternalName, experience);
-			return level < this.GetLevel();
-		}
+            throw new NotImplementedException();
+        }
 
-		/// <returns>Total accumulated experience.</returns>
-		public int GetTotalCurrentExperience()
-		{
-			return SpaceCore.Skills.GetExperienceFor(Game1.player, CookingSkill.InternalName);
-		}
+        /// <summary>
+        /// Add experience to the skill.
+        /// Experience gains from cooking may be applied via CalculateExperienceGainedFromCookingItem. This method should not be used where CalculateExperience would be more appropriate.
+        /// </summary>
+        /// <returns>Whether the player gained a level from added experience.</returns>
+        public bool AddExperienceDirectly(int experience)
+        {
+            Events.InvokeOnCookingExperienceGained(experienceGained: experience);
 
-		/// <returns>Experience required to reach this level from the previous level.</returns>
-		public int GetExperienceRequiredForLevel(int level)
-		{
-			CookingSkill skill = this.GetSkill();
-			return level > 0 && level <= skill.ExperienceCurve.Length
-				? level switch
-				{
-					0 => 0,
-					1 => skill.ExperienceCurve[level - 1],
-					_ => skill.ExperienceCurve[level - 1] - skill.ExperienceCurve[level - 2]
-				}
-				: 0;
-		}
+            int level = this.GetLevel();
+            SpaceCore.Skills.AddExperience(Game1.player, CookingSkill.InternalName, experience);
+            return level < this.GetLevel();
+        }
 
-		/// <returns>Accumulated experience required to reach this level from zero.</returns>
-		public int GetTotalExperienceRequiredForLevel(int level)
-		{
-			CookingSkill skill = this.GetSkill();
-			return level > 0 && level <= skill.ExperienceCurve.Length
-				? skill.ExperienceCurve[level - 1]
-				: 0;
-		}
+        /// <returns>Total accumulated experience.</returns>
+        public int GetTotalCurrentExperience()
+        {
+            return SpaceCore.Skills.GetExperienceFor(Game1.player, CookingSkill.InternalName);
+        }
 
-		/// <returns>
-		/// Difference between total accumulated experience and experience required to reach level.
-		/// Negative if level is lower than current skill level.
-		/// </returns>
-		public int GetExperienceRemainingUntilLevel(int level)
-		{
-			return this.GetTotalExperienceRequiredForLevel(level) - this.GetTotalCurrentExperience();
-		}
+        /// <returns>Experience required to reach this level from the previous level.</returns>
+        public int GetExperienceRequiredForLevel(int level)
+        {
+            CookingSkill skill = this.GetSkill();
+            return level > 0 && level <= skill.ExperienceCurve.Length
+                ? level switch
+                {
+                    0 => 0,
+                    1 => skill.ExperienceCurve[level - 1],
+                    _ => skill.ExperienceCurve[level - 1] - skill.ExperienceCurve[level - 2]
+                }
+                : 0;
+        }
+
+        /// <returns>Accumulated experience required to reach this level from zero.</returns>
+        public int GetTotalExperienceRequiredForLevel(int level)
+        {
+            CookingSkill skill = this.GetSkill();
+            return level > 0 && level <= skill.ExperienceCurve.Length
+                ? skill.ExperienceCurve[level - 1]
+                : 0;
+        }
+
+        /// <returns>
+        /// Difference between total accumulated experience and experience required to reach level.
+        /// Negative if level is lower than current skill level.
+        /// </returns>
+        public int GetExperienceRemainingUntilLevel(int level)
+        {
+            return this.GetTotalExperienceRequiredForLevel(level) - this.GetTotalCurrentExperience();
+        }
 
         /// <returns>Table of recipes learned through leveling Cooking.</returns>
         public IList<string> GetAllLoveOfCookingRecipes()
         {
             return CraftingRecipe.cookingRecipes.Keys
-				.Where(s => s.StartsWith(ModEntry.AssetPrefix))
-				.ToList();
+                .Where(s => s.StartsWith(ModEntry.AssetPrefix))
+                .ToList();
         }
 
         /// <returns>Table of recipes learned through leveling Cooking.</returns>
         public IReadOnlyDictionary<int, IList<string>> GetAllLevelUpRecipes()
         {
-			IDictionary<int, IList<string>> recipes = new Dictionary<int, IList<string>>();
-			for (int level = 0; level <= 10; ++level)
+            IDictionary<int, IList<string>> recipes = new Dictionary<int, IList<string>>();
+            for (int level = 0; level <= 10; ++level)
             {
                 recipes.TryAdd(level, []);
             }
-			if ((CraftingRecipe.cookingRecipes ?? DataLoader.CookingRecipes(Game1.content)) is Dictionary<string, string> data)
+            if ((CraftingRecipe.cookingRecipes ?? DataLoader.CookingRecipes(Game1.content)) is Dictionary<string, string> data)
             {
                 foreach ((string key, string value) in data)
                 {
@@ -184,104 +195,153 @@ namespace LoveOfCooking.Objects
                     }
                 }
             }
-			return (IReadOnlyDictionary<int, IList<string>>)recipes;
+            return (IReadOnlyDictionary<int, IList<string>>)recipes;
         }
 
         /// <returns>New recipes learned when reaching this level.</returns>
         public IReadOnlyList<string> GetCookingRecipesForLevel(int level)
-		{
-			return (IReadOnlyList<string>)(this.GetAllLevelUpRecipes().TryGetValue(level, out var value) ? value ?? [] : []);
-		}
+        {
+            return (IReadOnlyList<string>)(this.GetAllLevelUpRecipes().TryGetValue(level, out var value) ? value ?? [] : []);
+        }
 
-		/// <summary>
-		/// Calculates the experience to be gained from a certain food, and applies the gained experience to the Cooking skill if needed.
-		/// </summary>
-		/// <param name="item">Item to be cooked, used to determine whether the recipe has been cooked before.</param>
-		/// <param name="ingredientsCount">Number of ingredients used in the cooking recipe for this item.</param>
-		/// <param name="apply">Whether to apply experience gains to the skill.</param>
-		/// <returns>Experience gained.</returns>
-		public int CalculateExperienceGainedFromCookingItem(Item item, int ingredientsCount, int numCooked, bool apply)
-		{
-			CookingSkill skill = this.GetSkill();
+        /// <summary>
+        /// Calculates the experience to be gained from a certain food, and applies the gained experience to the Cooking skill if needed.
+        /// </summary>
+        /// <param name="item">Item to be cooked, used to determine whether the recipe has been cooked before.</param>
+        /// <param name="ingredientsCount">Number of ingredients used in the cooking recipe for this item.</param>
+        /// <param name="apply">Whether to apply experience gains to the skill.</param>
+        /// <returns>Experience gained.</returns>
+        public int CalculateExperienceGainedFromCookingItem(Item item, int ingredientsCount, int numCooked, bool apply)
+        {
+            CookingSkill skill = this.GetSkill();
 
-			// Reward players for cooking brand new recipes
-			int newBonus = Game1.player.recipesCooked.ContainsKey(item.ItemId)
-				? 0
-				: ModEntry.Definitions.CookingSkillValues.ExperienceNewRecipeBonus;
+            // Reward players for cooking brand new recipes
+            int newBonus = Game1.player.recipesCooked.ContainsKey(item.ItemId)
+                ? 0
+                : ModEntry.Definitions.CookingSkillValues.ExperienceNewRecipeBonus;
 
-			// Gain more experience for the first time cooking a meal each day
-			int dailyBonus = ModEntry.Instance.States.Value.FoodCookedToday.ContainsKey(item.Name)
-				? 0
-				: ModEntry.Definitions.CookingSkillValues.ExperienceDailyBonus;
+            // Gain more experience for the first time cooking a meal each day
+            int dailyBonus = ModEntry.Instance.States.Value.FoodCookedToday.ContainsKey(item.Name)
+                ? 0
+                : ModEntry.Definitions.CookingSkillValues.ExperienceDailyBonus;
 
-			if (!ModEntry.Instance.States.Value.FoodCookedToday.ContainsKey(item.Name))
-				ModEntry.Instance.States.Value.FoodCookedToday[item.Name] = 0;
+            if (!ModEntry.Instance.States.Value.FoodCookedToday.ContainsKey(item.Name))
+                ModEntry.Instance.States.Value.FoodCookedToday[item.Name] = 0;
 
-			// Gain less experience the more that the same food is cooked for this day
-			// magic-ass numbas
-			float stackBonus // (Quantity * (Rate of decay per quantity towards roughly 50%) / Some divisor for experience rate)
-				= Math.Min(numCooked, ModEntry.Definitions.CookingSkillValues.MaxFoodStackPerDayForExperienceGains)
-					* Math.Max(6f, 12f - ModEntry.Instance.States.Value.FoodCookedToday[item.Name]) / 8f;
+            // Gain less experience the more that the same food is cooked for this day
+            // magic-ass numbas
+            float stackBonus // (Quantity * (Rate of decay per quantity towards roughly 50%) / Some divisor for experience rate)
+                = Math.Min(numCooked, ModEntry.Definitions.CookingSkillValues.MaxFoodStackPerDayForExperienceGains)
+                    * Math.Max(6f, 12f - ModEntry.Instance.States.Value.FoodCookedToday[item.Name]) / 8f;
 
-			// Gain more experience for recipe complexity
-			float ingredientsBonus = ModEntry.Definitions.CookingSkillValues.ExperienceIngredientsBaseValue
-				+ (ingredientsCount * ModEntry.Definitions.CookingSkillValues.ExperienceIngredientsBonusScaling);
-			float experienceFromIngredients = ModEntry.Definitions.CookingSkillValues.ExperienceIngredientsFinalBaseValue
-				+ (ingredientsBonus * ModEntry.Definitions.CookingSkillValues.ExperienceIngredientsBonusFinalMultiplier);
+            // Gain more experience for recipe complexity
+            float ingredientsBonus = ModEntry.Definitions.CookingSkillValues.ExperienceIngredientsBaseValue
+                + (ingredientsCount * ModEntry.Definitions.CookingSkillValues.ExperienceIngredientsBonusScaling);
+            float experienceFromIngredients = ModEntry.Definitions.CookingSkillValues.ExperienceIngredientsFinalBaseValue
+                + (ingredientsBonus * ModEntry.Definitions.CookingSkillValues.ExperienceIngredientsBonusFinalMultiplier);
 
-			// Sum up experience
-			int currentLevel = this.GetLevel();
-			int finalExperience = 0;
+            // Sum up experience
+            int currentLevel = this.GetLevel();
+            int finalExperience = 0;
 
-			if (currentLevel >= skill.ExperienceCurve.Length)
-			{
-				Log.D($"No experience was applied: Skill is at max level.",
-					ModEntry.Config.DebugMode);
-			}
-			else
-			{
-				int nextLevel = currentLevel + 1;
-				int remainingExperience = this.GetExperienceRemainingUntilLevel(nextLevel);
-				int requiredExperience = this.GetExperienceRequiredForLevel(nextLevel);
-				int summedExperience = (int)(newBonus + dailyBonus + (experienceFromIngredients * stackBonus));
-				summedExperience = (int)(summedExperience * ModEntry.Definitions.CookingSkillValues.ExperienceGlobalScaling);
-				if (ModEntry.Config.DebugMode)
+            if (currentLevel >= skill.ExperienceCurve.Length)
+            {
+                Log.D($"No experience was applied: Skill is at max level.",
+                    ModEntry.Config.DebugMode);
+            }
+            else
+            {
+                int nextLevel = currentLevel + 1;
+                int remainingExperience = this.GetExperienceRemainingUntilLevel(nextLevel);
+                int requiredExperience = this.GetExperienceRequiredForLevel(nextLevel);
+                int summedExperience = (int)(newBonus + dailyBonus + (experienceFromIngredients * stackBonus));
+                summedExperience = (int)(summedExperience * ModEntry.Definitions.CookingSkillValues.ExperienceGlobalScaling);
+                if (ModEntry.Config.DebugMode)
                 {
-					summedExperience = (int)(summedExperience * ModEntry.DebugGlobalExperienceRate);
-				}
-				finalExperience = skill.ExperienceCurve.Length - currentLevel == 1
-					? Math.Min(remainingExperience, summedExperience)
-					: summedExperience;
-				Log.D($"Cooked up {item.Name} with {ingredientsCount} ingredients.",
-					ModEntry.Config.DebugMode);
+                    summedExperience = (int)(summedExperience * ModEntry.DebugGlobalExperienceRate);
+                }
+                finalExperience = skill.ExperienceCurve.Length - currentLevel == 1
+                    ? Math.Min(remainingExperience, summedExperience)
+                    : summedExperience;
+                Log.D($"Cooked up {item.Name} with {ingredientsCount} ingredients.",
+                    ModEntry.Config.DebugMode);
 
-				if (finalExperience < 1)
-				{
-					Log.D($"No experience was applied: None gained.",
-						ModEntry.Config.DebugMode);
-				}
-				else if (apply)
-				{
-					Log.D($"{Environment.NewLine}Experience until level {nextLevel}:"
-						+ $" ({requiredExperience - remainingExperience}/{requiredExperience})"
-						+ $"{Environment.NewLine}Total experience: ({this.GetTotalCurrentExperience()}/{this.GetTotalExperienceRequiredForLevel(nextLevel)})"
-						+ $"{Environment.NewLine}+{finalExperience} experience!",
-						ModEntry.Config.DebugMode);
-					this.AddExperienceDirectly(finalExperience);
-				}
-				else
-				{
-					Log.D($"No experience was applied: Probe.",
-						ModEntry.Config.DebugMode);
-				}
-			}
+                if (finalExperience < 1)
+                {
+                    Log.D($"No experience was applied: None gained.",
+                        ModEntry.Config.DebugMode);
+                }
+                else if (apply)
+                {
+                    Log.D($"{Environment.NewLine}Experience until level {nextLevel}:"
+                        + $" ({requiredExperience - remainingExperience}/{requiredExperience})"
+                        + $"{Environment.NewLine}Total experience: ({this.GetTotalCurrentExperience()}/{this.GetTotalExperienceRequiredForLevel(nextLevel)})"
+                        + $"{Environment.NewLine}+{finalExperience} experience!",
+                        ModEntry.Config.DebugMode);
+                    this.AddExperienceDirectly(finalExperience);
+                }
+                else
+                {
+                    Log.D($"No experience was applied: Probe.",
+                        ModEntry.Config.DebugMode);
+                }
+            }
 
-			return finalExperience;
-		}
+            return finalExperience;
+        }
 
-		public bool RollForExtraPortion()
-		{
-			return Game1.random.NextDouble() < ModEntry.Definitions.CookingSkillValues.ExtraPortionChance;
-		}
-	}
+        public bool RollForExtraPortion()
+        {
+            return Game1.random.NextDouble() < ModEntry.Definitions.CookingSkillValues.ExtraPortionChance;
+        }
+
+        /// <summary>
+        /// A list of events that should be run after the crafting process. One event is fired for every batch cook.
+        /// These events are currently not fired for burnt items.
+        /// </summary>
+        public event Action<IPostCookEvent>? PostCook;
+
+        internal void FirePostCookEvents(PostCookEvent ev)
+        {
+            if (PostCook is null) return;
+            foreach (Action<IPostCookEvent> del in PostCook.GetInvocationList())
+            {
+                try
+                {
+                    del.Invoke(ev);
+                }
+                catch (Exception e)
+                {
+                    Log.E("Error processing post cook events: " + e.ToString());
+                }
+            }
+        }
+    }
+
+    public class PostCookEvent : IPostCookEvent
+    {
+        /// <summary>
+        /// The recipe being cooked
+        /// </summary>
+        public CraftingRecipe Recipe { get; }
+        /// <summary>
+        /// The farmer cooking this recipe
+        /// </summary>
+        public Farmer Player { get; }
+        /// <summary>
+        /// The items that were cooked. This list can be mutated to change the output.
+        /// </summary>
+        public IList<StardewValley.Object> CookedItems { get; set; }
+        /// <summary>
+        /// The list of items that were consumed as ingredients. Each list corresponds to one individual craft.
+        /// /// </summary>
+        public IList<IList<Item>> ConsumedItems { get; }
+        public PostCookEvent(CraftingRecipe recipe, Farmer player, IList<StardewValley.Object> cookedItems, IList<IList<Item>> consumedItems)
+        {
+            this.Recipe = recipe;
+            this.Player = player;
+            this.CookedItems = cookedItems;
+            this.ConsumedItems = consumedItems;
+        }
+    }
 }

--- a/LoveOfCooking/Objects/CookingTool.cs
+++ b/LoveOfCooking/Objects/CookingTool.cs
@@ -4,92 +4,92 @@ using StardewValley;
 
 namespace LoveOfCooking.Objects
 {
-	public static class CookingTool
-	{
-		public const string InternalName = ModEntry.ObjectPrefix + "cookingtool"; // DO NOT EDIT
-		public const int DaysToUpgrade = 2;
-		public const int MaxUpgradeLevel = 4;
-		public const int MinIngredients = 1;
-		public const int MaxIngredients = 6;
-		public enum Level
-		{
-			Basic,
-			Copper,
-			Steel,
-			Gold,
-			Iridium
-		}
+    public static class CookingTool
+    {
+        public const string InternalName = ModEntry.ObjectPrefix + "cookingtool"; // DO NOT EDIT
+        public const int DaysToUpgrade = 2;
+        public const int MaxUpgradeLevel = 4;
+        public const int MinIngredients = 1;
+        public const int MaxIngredients = 6;
+        public enum Level
+        {
+            Basic,
+            Copper,
+            Steel,
+            Gold,
+            Iridium
+        }
 
-		/// <summary>
-		/// Performs most behaviours from <see cref="Tool.actionWhenPurchased"/>, 
-		/// </summary>
-		public static void ActionWhenPurchased(Tool tool)
-		{
-			Game1.player.toolBeingUpgraded.Value = tool;
-			Game1.player.daysLeftForToolUpgrade.Value = CookingTool.DaysToUpgrade;
-			Game1.exitActiveMenu();
-			Game1.playSound("parry");
-			Game1.DrawDialogue(npc: Game1.getCharacterFromName("Clint"), translationKey: "Strings\\StringsFromCSFiles:Tool.cs.14317");
-		}
+        /// <summary>
+        /// Performs most behaviours from <see cref="Tool.actionWhenPurchased"/>, 
+        /// </summary>
+        public static void ActionWhenPurchased(Tool tool)
+        {
+            Game1.player.toolBeingUpgraded.Value = tool;
+            Game1.player.daysLeftForToolUpgrade.Value = CookingTool.DaysToUpgrade;
+            Game1.exitActiveMenu();
+            Game1.playSound("parry");
+            Game1.DrawDialogue(npc: Game1.getCharacterFromName("Clint"), translationKey: "Strings\\StringsFromCSFiles:Tool.cs.14317");
+        }
 
-		/// <summary>
-		/// Adds custom behaviour for receiving an upgraded <see cref="CookingTool"/> from the Blacksmith.
-		/// </summary>
-		public static void ActionWhenClaimed(Tool tool)
-		{
-			ModEntry.Instance.States.Value.CookingToolLevel = tool.UpgradeLevel;
+        /// <summary>
+        /// Adds custom behaviour for receiving an upgraded <see cref="CookingTool"/> from the Blacksmith.
+        /// </summary>
+        public static void ActionWhenClaimed(Tool tool)
+        {
+            ModEntry.Instance.States.Value.CookingToolLevel = tool.UpgradeLevel;
 
-			// Ensure wallet items list is updated for latest tool level
-			ModEntry.Instance.Helper.GameContent.InvalidateCacheAndLocalized(@"Data/Powers");
-		}
+            // Ensure wallet items list is updated for latest tool level
+            ModEntry.Instance.Helper.GameContent.InvalidateCacheAndLocalized(@"Data/Powers");
+        }
 
-		/// <summary>
-		/// Whether the player can upgrade their cooking tool.
-		/// </summary>
-		public static bool UpgradePreconditions(Farmer who)
-		{
-			// Player must have read the cookbook mail
-			return Utils.HasCookbook(who);
-		}
+        /// <summary>
+        /// Whether the player can upgrade their cooking tool.
+        /// </summary>
+        public static bool UpgradePreconditions(Farmer who)
+        {
+            // Player must have read the cookbook mail
+            return Utils.HasCookbook(who);
+        }
 
-		/// <summary>
-		/// Checks whether any item is effectively considered a cooking tool.
-		/// </summary>
-		public static bool IsInstance(ISalable item)
-		{
-			return item?.Name?.StartsWith(CookingTool.InternalName) ?? false;
-		}
+        /// <summary>
+        /// Checks whether any item is effectively considered a cooking tool.
+        /// </summary>
+        public static bool IsInstance(ISalable item)
+        {
+            return item?.Name?.StartsWith(CookingTool.InternalName) ?? false;
+        }
 
-		/// <summary>
-		/// Returns a valid upgrade level usable anywhere expecting a value representing a <see cref="Tool.UpgradeLevel"/>.
-		/// </summary>
-		public static int GetEffectiveGlobalLevel()
-		{
-			// With tool progression disabled, the effective upgrade level will always be the maximum value
-			int level = (ModEntry.Config.AddCookingToolProgression && ModEntry.Instance.States.Value.CookingToolLevel < CookingTool.MaxUpgradeLevel)
-				? Math.Max(0, Math.Min(CookingTool.MaxUpgradeLevel, ModEntry.Instance.States.Value.CookingToolLevel))
-				: CookingTool.MaxUpgradeLevel;
-			return level;
-		}
+        /// <summary>
+        /// Returns a valid upgrade level usable anywhere expecting a value representing a <see cref="Tool.UpgradeLevel"/>.
+        /// </summary>
+        public static int GetEffectiveGlobalLevel()
+        {
+            // With tool progression disabled, the effective upgrade level will always be the maximum value
+            int level = (ModEntry.Config.AddCookingToolProgression && ModEntry.Instance.States.Value.CookingToolLevel < CookingTool.MaxUpgradeLevel)
+                ? Math.Max(0, Math.Min(CookingTool.MaxUpgradeLevel, ModEntry.Instance.States.Value.CookingToolLevel))
+                : CookingTool.MaxUpgradeLevel;
+            return level;
+        }
 
-		/// <summary>
-		/// Returns the effective usable ingredients count for the <see cref="CookingMenu"/> based on some <paramref name="level"/>.
-		/// </summary>
-		public static int NumIngredientsAllowed(int level)
-		{
-			return level < CookingTool.MaxUpgradeLevel
-				? CookingTool.MinIngredients + level
-				: CookingTool.MaxIngredients;
-		}
+        /// <summary>
+        /// Returns the effective usable ingredients count for the <see cref="CookingMenu"/> based on some <paramref name="level"/>.
+        /// </summary>
+        public static int NumIngredientsAllowed(int level)
+        {
+            return level < CookingTool.MaxUpgradeLevel
+                ? CookingTool.MinIngredients + level
+                : CookingTool.MaxIngredients;
+        }
 
-		public static string WalletID(int level)
-		{
-			return CookingTool.InternalName;
-		}
+        public static string WalletID(int level)
+        {
+            return CookingTool.InternalName;
+        }
 
-		public static string ToolID(int level)
-		{
-			return $"{CookingTool.InternalName}.level{level}";
-		}
-	}
+        public static string ToolID(int level)
+        {
+            return $"{CookingTool.InternalName}.level{level}";
+        }
+    }
 }


### PR DESCRIPTION
This new event allows other mods to register new events that can modify the cooked items depending on the ingredients used (aka Extra Machine Config's flavored cooking feature). The event is fired once per batch cook, and happens just right before the final items get added into the player inventory.

As part of the change refactor how the API object is instantiated to avoid clearing it every time, and the event queue with it.

(Sorry for the large diff my editor autoformats on save lmao. You can enable "ignore whitespace" when viewing the changes).