### PR TITLE
Slight RegenBar Adjustment

### DIFF
--- a/LoveOfCooking/Objects/Regeneration.cs
+++ b/LoveOfCooking/Objects/Regeneration.cs
@@ -349,7 +349,7 @@ namespace LoveOfCooking
 			int sourceWidth = AssetManager.RegenBarArea.Width;
 			int sourceHeight = AssetManager.RegenBarArea.Height;
 			Vector2 regenBarOrigin = new Vector2(
-				x: viewport.Right - (sourceWidth (1 + otherBarCount) * Game1.pixelZoom) - (otherBarWidth * (1 + otherBarCount)),
+				x: viewport.Right - (sourceWidth * (1 + otherBarCount) * Game1.pixelZoom) - (otherBarWidth * (1 + otherBarCount)),
 				y: viewport.Bottom - heightFromBottom - (sourceHeight * Game1.pixelZoom));
 
 			// Regen bar sprites

--- a/LoveOfCooking/Objects/Regeneration.cs
+++ b/LoveOfCooking/Objects/Regeneration.cs
@@ -349,7 +349,7 @@ namespace LoveOfCooking
 			int sourceWidth = AssetManager.RegenBarArea.Width;
 			int sourceHeight = AssetManager.RegenBarArea.Height;
 			Vector2 regenBarOrigin = new Vector2(
-				x: viewport.Right - (sourceWidth (1 + otherBarCount) * Game1.pixelZoom) - (otherBarWidth * otherBarCount),
+				x: viewport.Right - (sourceWidth (1 + otherBarCount) * Game1.pixelZoom) - (otherBarWidth * (1 + otherBarCount)),
 				y: viewport.Bottom - heightFromBottom - (sourceHeight * Game1.pixelZoom));
 
 			// Regen bar sprites

--- a/LoveOfCooking/Objects/Regeneration.cs
+++ b/LoveOfCooking/Objects/Regeneration.cs
@@ -349,7 +349,7 @@ namespace LoveOfCooking
 			int sourceWidth = AssetManager.RegenBarArea.Width;
 			int sourceHeight = AssetManager.RegenBarArea.Height;
 			Vector2 regenBarOrigin = new Vector2(
-				x: viewport.Right - (sourceWidth * (1 + otherBarCount) * Game1.pixelZoom) - (otherBarWidth * (1 + otherBarCount)),
+				x: viewport.Right - ((sourceWidth * (1 + otherBarCount)) * Game1.pixelZoom) - (otherBarWidth * (1 + otherBarCount)),
 				y: viewport.Bottom - heightFromBottom - (sourceHeight * Game1.pixelZoom));
 
 			// Regen bar sprites

--- a/LoveOfCooking/Objects/Regeneration.cs
+++ b/LoveOfCooking/Objects/Regeneration.cs
@@ -337,7 +337,7 @@ namespace LoveOfCooking
 			Rectangle viewport = Game1.graphics.GraphicsDevice.Viewport.TitleSafeArea;
 
 			const int heightFromBottom = 4 * Game1.pixelZoom;
-			const int otherBarWidth = 12 * Game1.pixelZoom;
+			const int otherBarWidth = 2 * Game1.pixelZoom;
 			const int otherBarSpacing = 1 * Game1.pixelZoom;
 
 			Point barIconOffset = new Point(x: -1, y: 1);
@@ -349,7 +349,7 @@ namespace LoveOfCooking
 			int sourceWidth = AssetManager.RegenBarArea.Width;
 			int sourceHeight = AssetManager.RegenBarArea.Height;
 			Vector2 regenBarOrigin = new Vector2(
-				x: viewport.Right - (sourceWidth * Game1.pixelZoom / 2) - (otherBarWidth * (1 + otherBarCount)),
+				x: viewport.Right - (sourceWidth (1 + otherBarCount) * Game1.pixelZoom) - (otherBarWidth * otherBarCount),
 				y: viewport.Bottom - heightFromBottom - (sourceHeight * Game1.pixelZoom));
 
 			// Regen bar sprites


### PR DESCRIPTION
The Bar was off by a couple pixels and it gets worse with more BarCount, this fixes this. 

Was attempting to take into account modded Bars, snapping this bar onto those so this always ends up being the left most. I did add on my end detection for "[Magic Stardew](https://www.nexusmods.com/stardewvalley/mods/36609)" as that was my focus, but was not able to yet make an automatic generic fits all so I left out that work, maybe in another PR but no promises. 


I would change the name for "otherBarWidth" to something else like Padding. (This is the only use of it on this file)

I would test this before adding it officially just encase.